### PR TITLE
Easy fix of exception returning id function instead of job id

### DIFF
--- a/apscheduler/jobstores/mongodb.py
+++ b/apscheduler/jobstores/mongodb.py
@@ -98,7 +98,7 @@ class MongoDBJobStore(BaseJobStore):
         }
         result = self.collection.update({'_id': job.id}, {'$set': changes})
         if result and result['n'] == 0:
-            raise JobLookupError(id)
+            raise JobLookupError(job.id)
 
     def remove_job(self, job_id):
         result = self.collection.remove(job_id)


### PR DESCRIPTION
I have no idea on how to test this thing. I suppose it would mean modifying test_jobstores:test_update_job_nonexistent_job() but I don't know how to test that the attribute we complain of is 'blah' and not any other.