### PR TITLE
CronTrigger behavior around DST transitions

### DIFF
--- a/apscheduler/triggers/cron/__init__.py
+++ b/apscheduler/triggers/cron/__init__.py
@@ -180,13 +180,13 @@ class CronTrigger(BaseTrigger):
         # check if a switch from no dst to dst falls into the 24 hours before the next date
         if next_date \
                 and next_date.dst() > self.timezone.normalize(next_date - timedelta(days=1)).dst():
-            # perform a fixed point iteration to cope with "missing time" 
+            # perform a fixed point iteration to cope with "missing time"
             # due to a switch from winter to summer time
             last_date = None
             loops = 0
             while last_date != next_date:
                 if loops > 10 and next_date - start_date > timedelta(days=5*365):
-                    # if there's no valid fire time in the next ~5 years, 
+                    # if there's no valid fire time in the next ~5 years,
                     # then give up and return "no next fire time"
                     return None
 

--- a/apscheduler/triggers/cron/__init__.py
+++ b/apscheduler/triggers/cron/__init__.py
@@ -133,7 +133,7 @@ class CronTrigger(BaseTrigger):
                     values[field.name] = new_value
 
         return self.timezone.normalize(self.timezone.localize(datetime(**values),
-                                       is_dst=dateval.dst()))
+                                                              is_dst=dateval.dst()))
 
     def _find_next_potential_fire_time(self, start_date):
         next_date = start_date
@@ -178,8 +178,8 @@ class CronTrigger(BaseTrigger):
         next_date = self._find_next_potential_fire_time(start_date)
 
         # check if a switch from no dst to dst falls into the 24 hours before the next date
-        if next_date \
-                and next_date.dst() > self.timezone.normalize(next_date - timedelta(days=1)).dst():
+        if (next_date and
+                next_date.dst() > self.timezone.normalize(next_date - timedelta(days=1)).dst()):
             # perform a fixed point iteration to cope with "missing time"
             # due to a switch from winter to summer time
             last_date = None

--- a/apscheduler/triggers/cron/__init__.py
+++ b/apscheduler/triggers/cron/__init__.py
@@ -132,16 +132,11 @@ class CronTrigger(BaseTrigger):
                 else:
                     values[field.name] = new_value
 
-        return self.timezone.localize(datetime(**values))
+        return self.timezone.normalize(self.timezone.localize(datetime(**values),
+                                       is_dst=dateval.dst()))
 
-    def get_next_fire_time(self, previous_fire_time, now):
-        if previous_fire_time:
-            start_date = min(now, previous_fire_time + timedelta(microseconds=1))
-            if start_date == previous_fire_time:
-                start_date += timedelta(microseconds=1)
-        else:
-            start_date = max(now, self.start_date) if self.start_date else now
-
+    def _find_next_potential_fire_time(self, start_date):
+        next_date = start_date
         fieldnum = 0
         next_date = datetime_ceil(start_date).astimezone(self.timezone)
         while 0 <= fieldnum < len(self.fields):
@@ -169,6 +164,38 @@ class CronTrigger(BaseTrigger):
 
         if fieldnum >= 0:
             return next_date
+
+    def get_next_fire_time(self, previous_fire_time, now):
+        if previous_fire_time:
+            start_date = min(now, previous_fire_time + timedelta(microseconds=1))
+            if start_date == previous_fire_time:
+                start_date += timedelta(microseconds=1)
+        else:
+            start_date = max(now, self.start_date) if self.start_date else now
+
+        start_date = datetime_ceil(start_date).astimezone(self.timezone)
+
+        next_date = self._find_next_potential_fire_time(start_date)
+
+        # check if a switch from no dst to dst falls into the 24 hours before the next date
+        if next_date \
+                and next_date.dst() > self.timezone.normalize(next_date - timedelta(days=1)).dst():
+            # perform a fixed point iteration to cope with "missing time" 
+            # due to a switch from winter to summer time
+            last_date = None
+            loops = 0
+            while last_date != next_date:
+                if loops > 10 and next_date - start_date > timedelta(days=5*365):
+                    # if there's no valid fire time in the next ~5 years, 
+                    # then give up and return "no next fire time"
+                    return None
+
+                last_date = next_date
+                loops += 1
+
+                next_date = self._find_next_potential_fire_time(last_date)
+
+        return next_date
 
     def __getstate__(self):
         return {

--- a/apscheduler/triggers/cron/__init__.py
+++ b/apscheduler/triggers/cron/__init__.py
@@ -160,7 +160,6 @@ class CronTrigger(BaseTrigger):
                                                               is_dst=dateval.dst()))
 
     def _find_next_potential_fire_time(self, start_date):
-        next_date = start_date
         fieldnum = 0
         next_date = datetime_ceil(start_date).astimezone(self.timezone)
         while 0 <= fieldnum < len(self.fields):
@@ -187,8 +186,6 @@ class CronTrigger(BaseTrigger):
                 return None
 
         if fieldnum >= 0:
-            if self.jitter is not None:
-                next_date = self._apply_jitter(next_date, self.jitter, now)
             return next_date
 
     def get_next_fire_time(self, previous_fire_time, now):
@@ -221,6 +218,8 @@ class CronTrigger(BaseTrigger):
 
                 next_date = self._find_next_potential_fire_time(last_date)
 
+        if self.jitter is not None:
+            next_date = self._apply_jitter(next_date, self.jitter, now)
         return next_date
 
     def __getstate__(self):

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -200,35 +200,40 @@ class TestCronTrigger(object):
         correct_next_date = timezone.localize(datetime(2009, 4, 8))
         assert trigger.get_next_fire_time(None, start_date) == correct_next_date
 
-    @pytest.mark.parametrize('trigger_args, start_date, start_date_dst, '
-                             'correct_next_date_dst, correct_next_date', [
-        ({'hour': (DST_SPRING.hour + 12) % 24}, DST_SPRING - timedelta(hours=6), False,
-         True, DST_SPRING + timedelta(hours=12)),
-        ({'hour': (DST_AUTUMN.hour + 12) % 24}, DST_AUTUMN - timedelta(hours=6), True,
-         False, DST_AUTUMN + timedelta(hours=12)),
-        ({'minute': 30}, DST_AUTUMN - timedelta(hours=0.25), True,
-         True, DST_AUTUMN + timedelta(hours=0.5)),
-        ({'minute': 30}, DST_AUTUMN + timedelta(hours=0.75), True,
-         False, DST_AUTUMN + timedelta(hours=0.5)),
-        ({'minute': 30}, DST_AUTUMN + timedelta(hours=0.75), False,
-         False, DST_AUTUMN + timedelta(hours=1.5)),
-        ({'hour': '*'}, DST_SPRING - timedelta(hours=0.25), True,
-         False, DST_SPRING + timedelta(hours=1)),
-        ({'hour': DST_SPRING.hour, 'minute': 30}, DST_SPRING - timedelta(hours=6), True,
-         False, DST_SPRING + timedelta(hours=24.5)),
-        ({'minute': '*/30'}, DST_SPRING - timedelta(hours=0.25), False,
-         True, DST_SPRING + timedelta(hours=1)),
-        ({'minute': '*/30'}, DST_AUTUMN - timedelta(hours=0.25), True,
-         True, DST_AUTUMN),
-        ({'minute': '*/30'}, DST_AUTUMN + timedelta(hours=0.25), True,
-         True, DST_AUTUMN + timedelta(hours=0.5)),
-        ({'minute': '*/30'}, DST_AUTUMN + timedelta(hours=0.75), True,
-         False, DST_AUTUMN),
-    ], ids=['absolute_spring', 'absolute_autumn',
+    @pytest.mark.parametrize(
+        'trigger_args, start_date, start_date_dst, correct_next_date_dst, correct_next_date',
+        [
+            ({'hour': (DST_SPRING.hour + 12) % 24}, DST_SPRING - timedelta(hours=6), False,
+             True, DST_SPRING + timedelta(hours=12)),
+            ({'hour': (DST_AUTUMN.hour + 12) % 24}, DST_AUTUMN - timedelta(hours=6), True,
+             False, DST_AUTUMN + timedelta(hours=12)),
+            ({'minute': 30}, DST_AUTUMN - timedelta(hours=0.25), True,
+             True, DST_AUTUMN + timedelta(hours=0.5)),
+            ({'minute': 30}, DST_AUTUMN + timedelta(hours=0.75), True,
+             False, DST_AUTUMN + timedelta(hours=0.5)),
+            ({'minute': 30}, DST_AUTUMN + timedelta(hours=0.75), False,
+             False, DST_AUTUMN + timedelta(hours=1.5)),
+            ({'hour': '*'}, DST_SPRING - timedelta(hours=0.25), True,
+             False, DST_SPRING + timedelta(hours=1)),
+            ({'hour': DST_SPRING.hour, 'minute': 30}, DST_SPRING - timedelta(hours=6), True,
+             False, DST_SPRING + timedelta(hours=24.5)),
+            ({'minute': '*/30'}, DST_SPRING - timedelta(hours=0.25), False,
+             True, DST_SPRING + timedelta(hours=1)),
+            ({'minute': '*/30'}, DST_AUTUMN - timedelta(hours=0.25), True,
+             True, DST_AUTUMN),
+            ({'minute': '*/30'}, DST_AUTUMN + timedelta(hours=0.25), True,
+             True, DST_AUTUMN + timedelta(hours=0.5)),
+            ({'minute': '*/30'}, DST_AUTUMN + timedelta(hours=0.75), True,
+             False, DST_AUTUMN),
+        ],
+        ids=[
+            'absolute_spring', 'absolute_autumn',
             'repeat_hour_enter', 'repeat_hour', 'repeat_hour_exit',
             'interval_skipped_hour', 'absolute_skipped_hour',
             'interval_spring', 'interval_autumn_enter',
-            'interval_autumn', 'interval_autumn_exit'])
+            'interval_autumn', 'interval_autumn_exit',
+        ],
+    )
     def test_dst_change(self, trigger_args, start_date, start_date_dst,
                         correct_next_date_dst, correct_next_date):
         """

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -10,8 +10,8 @@ from apscheduler.triggers.interval import IntervalTrigger
 
 
 DST_TIMEZONE = 'Europe/Berlin'
-DST_AUTUMN = datetime(2015, 10, 25, 2)  # must be top of the hour and the following hour is repeated
-DST_SPRING = datetime(2016, 3, 27, 2)  # must be top of the hour and the following hour is skipped
+DST_AUTUMN = datetime(2015, 10, 25, 2)  # must be top of the hour. the following hour is repeated
+DST_SPRING = datetime(2016, 3, 27, 2)  # must be top of the hour. the following hour is skipped
 
 
 class TestCronTrigger(object):

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -231,7 +231,7 @@ class TestCronTrigger(object):
         start_date = timezone.localize(start_date, is_dst=start_date_dst)
         correct_next_date = timezone.localize(correct_next_date, is_dst=correct_next_date_dst)
         next_date = trigger.get_next_fire_time(None, start_date)
-        print 'trigger', trigger, 'start', start_date, 'expected next', correct_next_date, 'got next', next_date
+        print('trigger', trigger, 'start', start_date, 'expected next', correct_next_date, 'got next', next_date)
         assert str(next_date) == str(correct_next_date)
 
     def test_dst_missing_hour(self):

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -246,15 +246,14 @@ class TestCronTrigger(object):
               correct_next_date, 'got next', next_date)
         assert str(next_date) == str(correct_next_date)
 
-    def test_dst_missing_hour(self):
+    def test_dst_missing_hour(self, timezone):
         """
         It might be that a CronTrigger can be configured to only ever fire in the missing
         time period during the switch from standard to daylight saving time,
         resulting in a trigger unable to fire.
 
         """
-        timezone = pytz.timezone('Europe/Berlin')
-        trigger = CronTrigger(timezone=timezone, month=3, day='last sun', hour=2, minute=30)
+        trigger = CronTrigger(month=3, day='last sun', hour=2, minute=30)
         start_date = timezone.localize(datetime(2006, 4, 1), is_dst=False)
         next_date = trigger.get_next_fire_time(None, start_date)
         assert next_date is None

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -200,30 +200,41 @@ class TestCronTrigger(object):
         correct_next_date = timezone.localize(datetime(2009, 4, 8))
         assert trigger.get_next_fire_time(None, start_date) == correct_next_date
 
-    @pytest.mark.parametrize('trigger_args, start_date, start_date_dst, correct_next_date_dst, correct_next_date', [
-        ({'hour': (DST_SPRING.hour + 12) % 24}, DST_SPRING - timedelta(hours=6), False, True,
-         DST_SPRING + timedelta(hours=12)),
-        ({'hour': (DST_AUTUMN.hour + 12) % 24}, DST_AUTUMN - timedelta(hours=6), True, False,
-         DST_AUTUMN + timedelta(hours=12)),
-        ({'minute': 30}, DST_AUTUMN - timedelta(hours=0.25), True, True, DST_AUTUMN + timedelta(hours=0.5)),
-        ({'minute': 30}, DST_AUTUMN + timedelta(hours=0.75), True, False, DST_AUTUMN + timedelta(hours=0.5)),
-        ({'minute': 30}, DST_AUTUMN + timedelta(hours=0.75), False, False, DST_AUTUMN + timedelta(hours=1.5)),
-        ({'hour': '*'}, DST_SPRING - timedelta(hours=0.25), True, False, DST_SPRING + timedelta(hours=1)),
-        ({'hour': DST_SPRING.hour, 'minute': 30}, DST_SPRING - timedelta(hours=6), True, False,
-         DST_SPRING + timedelta(hours=24.5)),
-        ({'minute': '*/30'}, DST_SPRING - timedelta(hours=0.25), False, True, DST_SPRING + timedelta(hours=1)),
-        ({'minute': '*/30'}, DST_AUTUMN - timedelta(hours=0.25), True, True, DST_AUTUMN),
-        ({'minute': '*/30'}, DST_AUTUMN + timedelta(hours=0.25), True, True, DST_AUTUMN + timedelta(hours=0.5)),
-        ({'minute': '*/30'}, DST_AUTUMN + timedelta(hours=0.75), True, False, DST_AUTUMN),
+    @pytest.mark.parametrize('trigger_args, start_date, start_date_dst, '
+                             'correct_next_date_dst, correct_next_date', [
+        ({'hour': (DST_SPRING.hour + 12) % 24}, DST_SPRING - timedelta(hours=6), False,
+         True, DST_SPRING + timedelta(hours=12)),
+        ({'hour': (DST_AUTUMN.hour + 12) % 24}, DST_AUTUMN - timedelta(hours=6), True,
+         False, DST_AUTUMN + timedelta(hours=12)),
+        ({'minute': 30}, DST_AUTUMN - timedelta(hours=0.25), True,
+         True, DST_AUTUMN + timedelta(hours=0.5)),
+        ({'minute': 30}, DST_AUTUMN + timedelta(hours=0.75), True,
+         False, DST_AUTUMN + timedelta(hours=0.5)),
+        ({'minute': 30}, DST_AUTUMN + timedelta(hours=0.75), False,
+         False, DST_AUTUMN + timedelta(hours=1.5)),
+        ({'hour': '*'}, DST_SPRING - timedelta(hours=0.25), True,
+         False, DST_SPRING + timedelta(hours=1)),
+        ({'hour': DST_SPRING.hour, 'minute': 30}, DST_SPRING - timedelta(hours=6), True,
+         False, DST_SPRING + timedelta(hours=24.5)),
+        ({'minute': '*/30'}, DST_SPRING - timedelta(hours=0.25), False,
+         True, DST_SPRING + timedelta(hours=1)),
+        ({'minute': '*/30'}, DST_AUTUMN - timedelta(hours=0.25), True,
+         True, DST_AUTUMN),
+        ({'minute': '*/30'}, DST_AUTUMN + timedelta(hours=0.25), True,
+         True, DST_AUTUMN + timedelta(hours=0.5)),
+        ({'minute': '*/30'}, DST_AUTUMN + timedelta(hours=0.75), True,
+         False, DST_AUTUMN),
     ], ids=['absolute_spring', 'absolute_autumn',
             'repeat_hour_enter', 'repeat_hour', 'repeat_hour_exit',
             'interval_skipped_hour', 'absolute_skipped_hour',
-            'interval_spring', 'interval_autumn_enter', 'interval_autumn', 'interval_autumn_exit'])
-    def test_dst_change(self, trigger_args, start_date, start_date_dst, correct_next_date_dst, correct_next_date):
+            'interval_spring', 'interval_autumn_enter',
+            'interval_autumn', 'interval_autumn_exit'])
+    def test_dst_change(self, trigger_args, start_date, start_date_dst,
+                        correct_next_date_dst, correct_next_date):
         """
         Making sure that CronTrigger works correctly when crossing the DST switch threshold.
-        Note that you should explicitly compare datetimes as strings to avoid the internal datetime
-        comparison which would test for equality in the UTC timezone.
+        Note that you should explicitly compare datetimes as strings to avoid the internal
+        datetime comparison which would test for equality in the UTC timezone.
 
         """
         timezone = pytz.timezone(DST_TIMEZONE)
@@ -231,13 +242,15 @@ class TestCronTrigger(object):
         start_date = timezone.localize(start_date, is_dst=start_date_dst)
         correct_next_date = timezone.localize(correct_next_date, is_dst=correct_next_date_dst)
         next_date = trigger.get_next_fire_time(None, start_date)
-        print('trigger', trigger, 'start', start_date, 'expected next', correct_next_date, 'got next', next_date)
+        print('trigger', trigger, 'start', start_date, 'expected next',
+              correct_next_date, 'got next', next_date)
         assert str(next_date) == str(correct_next_date)
 
     def test_dst_missing_hour(self):
         """
-        It might be that a CronTrigger can be configured to only ever fire in the missing time period during the switch
-        from standard to daylight saving time, resulting in a trigger unable to fire.
+        It might be that a CronTrigger can be configured to only ever fire in the missing
+        time period during the switch from standard to daylight saving time,
+        resulting in a trigger unable to fire.
 
         """
         timezone = pytz.timezone('Europe/Berlin')

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -9,6 +9,11 @@ from apscheduler.triggers.date import DateTrigger
 from apscheduler.triggers.interval import IntervalTrigger
 
 
+DST_TIMEZONE = 'Europe/Berlin'
+DST_AUTUMN = datetime(2015, 10, 25, 2)  # must be top of the hour and the following hour is repeated
+DST_SPRING = datetime(2016, 3, 27, 2)  # must be top of the hour and the following hour is skipped
+
+
 class TestCronTrigger(object):
     def test_cron_trigger_1(self, timezone):
         trigger = CronTrigger(year='2009/2', month='1/3', day='5-13', timezone=timezone)
@@ -195,24 +200,51 @@ class TestCronTrigger(object):
         correct_next_date = timezone.localize(datetime(2009, 4, 8))
         assert trigger.get_next_fire_time(None, start_date) == correct_next_date
 
-    @pytest.mark.parametrize('trigger_args, start_date, start_date_dst, correct_next_date', [
-        ({'hour': 8}, datetime(2013, 3, 9, 12), False, datetime(2013, 3, 10, 8)),
-        ({'hour': 8}, datetime(2013, 11, 2, 12), True, datetime(2013, 11, 3, 8)),
-        ({'minute': '*/30'}, datetime(2013, 3, 10, 1, 35), False, datetime(2013, 3, 10, 3)),
-        ({'minute': '*/30'}, datetime(2013, 11, 3, 1, 35), True, datetime(2013, 11, 3, 1))
-    ], ids=['absolute_spring', 'absolute_autumn', 'interval_spring', 'interval_autumn'])
-    def test_dst_change(self, trigger_args, start_date, start_date_dst, correct_next_date):
+    @pytest.mark.parametrize('trigger_args, start_date, start_date_dst, correct_next_date_dst, correct_next_date', [
+        ({'hour': (DST_SPRING.hour + 12) % 24}, DST_SPRING - timedelta(hours=6), False, True,
+         DST_SPRING + timedelta(hours=12)),
+        ({'hour': (DST_AUTUMN.hour + 12) % 24}, DST_AUTUMN - timedelta(hours=6), True, False,
+         DST_AUTUMN + timedelta(hours=12)),
+        ({'minute': 30}, DST_AUTUMN - timedelta(hours=0.25), True, True, DST_AUTUMN + timedelta(hours=0.5)),
+        ({'minute': 30}, DST_AUTUMN + timedelta(hours=0.75), True, False, DST_AUTUMN + timedelta(hours=0.5)),
+        ({'minute': 30}, DST_AUTUMN + timedelta(hours=0.75), False, False, DST_AUTUMN + timedelta(hours=1.5)),
+        ({'hour': '*'}, DST_SPRING - timedelta(hours=0.25), True, False, DST_SPRING + timedelta(hours=1)),
+        ({'hour': DST_SPRING.hour, 'minute': 30}, DST_SPRING - timedelta(hours=6), True, False,
+         DST_SPRING + timedelta(hours=24.5)),
+        ({'minute': '*/30'}, DST_SPRING - timedelta(hours=0.25), False, True, DST_SPRING + timedelta(hours=1)),
+        ({'minute': '*/30'}, DST_AUTUMN - timedelta(hours=0.25), True, True, DST_AUTUMN),
+        ({'minute': '*/30'}, DST_AUTUMN + timedelta(hours=0.25), True, True, DST_AUTUMN + timedelta(hours=0.5)),
+        ({'minute': '*/30'}, DST_AUTUMN + timedelta(hours=0.75), True, False, DST_AUTUMN),
+    ], ids=['absolute_spring', 'absolute_autumn',
+            'repeat_hour_enter', 'repeat_hour', 'repeat_hour_exit',
+            'interval_skipped_hour', 'absolute_skipped_hour',
+            'interval_spring', 'interval_autumn_enter', 'interval_autumn', 'interval_autumn_exit'])
+    def test_dst_change(self, trigger_args, start_date, start_date_dst, correct_next_date_dst, correct_next_date):
         """
         Making sure that CronTrigger works correctly when crossing the DST switch threshold.
         Note that you should explicitly compare datetimes as strings to avoid the internal datetime
         comparison which would test for equality in the UTC timezone.
 
         """
-        timezone = pytz.timezone('US/Eastern')
+        timezone = pytz.timezone(DST_TIMEZONE)
         trigger = CronTrigger(timezone=timezone, **trigger_args)
         start_date = timezone.localize(start_date, is_dst=start_date_dst)
-        correct_next_date = timezone.localize(correct_next_date, is_dst=not start_date_dst)
-        assert str(trigger.get_next_fire_time(None, start_date)) == str(correct_next_date)
+        correct_next_date = timezone.localize(correct_next_date, is_dst=correct_next_date_dst)
+        next_date = trigger.get_next_fire_time(None, start_date)
+        print 'trigger', trigger, 'start', start_date, 'expected next', correct_next_date, 'got next', next_date
+        assert str(next_date) == str(correct_next_date)
+
+    def test_dst_missing_hour(self):
+        """
+        It might be that a CronTrigger can be configured to only ever fire in the missing time period during the switch
+        from standard to daylight saving time, resulting in a trigger unable to fire.
+
+        """
+        timezone = pytz.timezone('Europe/Berlin')
+        trigger = CronTrigger(timezone=timezone, month=3, day='last sun', hour=2, minute=30)
+        start_date = timezone.localize(datetime(2006, 4, 1), is_dst=False)
+        next_date = trigger.get_next_fire_time(None, start_date)
+        assert next_date is None
 
     def test_timezone_change(self, timezone):
         """

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -253,7 +253,7 @@ class TestCronTrigger(object):
         resulting in a trigger unable to fire.
 
         """
-        trigger = CronTrigger(month=3, day='last sun', hour=2, minute=30)
+        trigger = CronTrigger(timezone=timezone, month=3, day='last sun', hour=2, minute=30)
         start_date = timezone.localize(datetime(2006, 4, 1), is_dst=False)
         next_date = trigger.get_next_fire_time(None, start_date)
         assert next_date is None


### PR DESCRIPTION
Hi @agronholm ,

I have been working on making the CronTrigger respect daylight saving time transitions and would gladly like to share this functionality with you.

Although I'm unsure if I managed to match your coding style, I kindly ask for a review of this PR.
Please let me know if it can be improved and if you would be willing to accept it.

I tried to ensure that the changes are compatible with your documentation (http://apscheduler.readthedocs.io/en/latest/modules/triggers/cron.html#daylight-saving-time-behavior) in the sense that they narrow down the behavior to "execute exactly when the cron trigger expression matches the wall clock in the time zone -- even considering daylight saving time."

Best regards and keep up the good work,
Tim
