### PR TITLE
Track lifecycle & history of jobs by storing `job_submissions` in jobstore

### DIFF
--- a/apscheduler/events.py
+++ b/apscheduler/events.py
@@ -85,8 +85,8 @@ class JobExecutionEvent(JobEvent):
     :ivar traceback: a formatted traceback for the exception
     """
 
-    def __init__(self, code, job_id, jobstore, scheduled_run_time, job_submission_id=None, retval=None, exception=None,
-                 traceback=None):
+    def __init__(self, code, job_id, jobstore, scheduled_run_time,
+                 job_submission_id=None, retval=None, exception=None, traceback=None):
         super(JobExecutionEvent, self).__init__(code, job_id, jobstore)
         self.scheduled_run_time = scheduled_run_time
         self.retval = retval

--- a/apscheduler/events.py
+++ b/apscheduler/events.py
@@ -85,10 +85,11 @@ class JobExecutionEvent(JobEvent):
     :ivar traceback: a formatted traceback for the exception
     """
 
-    def __init__(self, code, job_id, jobstore, scheduled_run_time, retval=None, exception=None,
+    def __init__(self, code, job_id, jobstore, scheduled_run_time, job_submission_id=None, retval=None, exception=None,
                  traceback=None):
         super(JobExecutionEvent, self).__init__(code, job_id, jobstore)
         self.scheduled_run_time = scheduled_run_time
         self.retval = retval
         self.exception = exception
         self.traceback = traceback
+        self.job_submission_id = job_submission_id

--- a/apscheduler/executors/asyncio.py
+++ b/apscheduler/executors/asyncio.py
@@ -29,12 +29,8 @@ class AsyncIOExecutor(BaseExecutor):
 
     def _do_submit_job(self, job, job_submission_id, run_time):
         def callback(f):
-            try:
-                events = f.result()
-            except:
-                self._run_job_error(job.id, job_submission_id, job._jobstore_alias, *sys.exc_info()[1:])
-            else:
-                self._run_job_success(job.id, job_submission_id, job._jobstore_alias, events)
+            event = f.result()
+            self._handle_job_event(event)
 
         if iscoroutinefunction(job.func):
             if run_coroutine_job is not None:

--- a/apscheduler/executors/asyncio.py
+++ b/apscheduler/executors/asyncio.py
@@ -6,7 +6,6 @@ from apscheduler.executors.base import BaseExecutor
 
 try:
     from asyncio import iscoroutinefunction
-    from apscheduler.executors.base_py3 import run_coroutine_job
 except ImportError:
     from trollius import iscoroutinefunction
     run_coroutine_job = None

--- a/apscheduler/executors/asyncio.py
+++ b/apscheduler/executors/asyncio.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import sys
 
-from apscheduler.executors.base import BaseExecutor, run_job
+from apscheduler.executors.base import BaseExecutor
 
 try:
     from asyncio import iscoroutinefunction
@@ -27,7 +27,7 @@ class AsyncIOExecutor(BaseExecutor):
         super(AsyncIOExecutor, self).start(scheduler, alias)
         self._eventloop = scheduler._eventloop
 
-    def _do_submit_job(self, job, run_times):
+    def _do_submit_job(self, job, run_times, run_job_func):
         def callback(f):
             try:
                 events = f.result()
@@ -43,7 +43,7 @@ class AsyncIOExecutor(BaseExecutor):
             else:
                 raise Exception('Executing coroutine based jobs is not supported with Trollius')
         else:
-            f = self._eventloop.run_in_executor(None, run_job, job, job._jobstore_alias, run_times,
+            f = self._eventloop.run_in_executor(None, run_job_func, job, job._jobstore_alias, run_times,
                                                 self._logger.name)
 
         f.add_done_callback(callback)

--- a/apscheduler/executors/asyncio.py
+++ b/apscheduler/executors/asyncio.py
@@ -32,18 +32,18 @@ class AsyncIOExecutor(BaseExecutor):
             try:
                 events = f.result()
             except:
-                self._run_job_error(job.id, *sys.exc_info()[1:])
+                self._run_job_error(job.id, job_submission_id, job._jobstore_alias, *sys.exc_info()[1:])
             else:
-                self._run_job_success(job.id, events)
+                self._run_job_success(job.id, job_submission_id, job._jobstore_alias, events)
 
         if iscoroutinefunction(job.func):
             if run_coroutine_job is not None:
-                coro = run_coroutine_job(job, self._logger.name, job_submission_id, run_time)
+                coro = run_coroutine_job(job, self._logger.name, job_submission_id, job._jobstore_alias, run_time)
                 f = self._eventloop.create_task(coro)
             else:
                 raise Exception('Executing coroutine based jobs is not supported with Trollius')
         else:
             f = self._eventloop.run_in_executor(None, run_job, job, self._logger.name,
-                                               job_submission_id, run_time)
+                                               job_submission_id, job._jobstore_alias, run_time)
 
         f.add_done_callback(callback)

--- a/apscheduler/executors/asyncio.py
+++ b/apscheduler/executors/asyncio.py
@@ -32,18 +32,23 @@ class AsyncIOExecutor(BaseExecutor):
             try:
                 events = f.result()
             except:
-                self._run_job_error(job.id, job_submission_id, job._jobstore_alias, *sys.exc_info()[1:])
+                self._run_job_error(job.id, job_submission_id, job._jobstore_alias,
+                                    *sys.exc_info()[1:])
             else:
                 self._run_job_success(job.id, job_submission_id, job._jobstore_alias, events)
 
         if iscoroutinefunction(job.func):
             if run_coroutine_job is not None:
-                coro = run_coroutine_job(job, self._logger.name, job_submission_id, job._jobstore_alias, run_time)
+                self._logger.info("Calling run_coroutine_job")
+                coro = run_coroutine_job(job, self._logger.name,
+                                         job_submission_id, job._jobstore_alias, run_time)
+                self._logger.info("Ran coroutine job")
                 f = self._eventloop.create_task(coro)
+                self._logger.info("Got future...")
             else:
                 raise Exception('Executing coroutine based jobs is not supported with Trollius')
         else:
             f = self._eventloop.run_in_executor(None, run_job, job, self._logger.name,
-                                               job_submission_id, job._jobstore_alias, run_time)
+                                                job_submission_id, job._jobstore_alias, run_time)
 
         f.add_done_callback(callback)

--- a/apscheduler/executors/asyncio.py
+++ b/apscheduler/executors/asyncio.py
@@ -2,10 +2,11 @@ from __future__ import absolute_import
 
 import sys
 
-from apscheduler.executors.base import BaseExecutor
+from apscheduler.executors.base import BaseExecutor, run_job
 
 try:
     from asyncio import iscoroutinefunction
+    from apscheduler.executors.base_py3 import run_coroutine_job
 except ImportError:
     from trollius import iscoroutinefunction
     run_coroutine_job = None
@@ -26,7 +27,7 @@ class AsyncIOExecutor(BaseExecutor):
         super(AsyncIOExecutor, self).start(scheduler, alias)
         self._eventloop = scheduler._eventloop
 
-    def _do_submit_job(self, job, run_times, run_job_func):
+    def _do_submit_job(self, job, job_submission_id, run_time):
         def callback(f):
             try:
                 events = f.result()
@@ -37,12 +38,12 @@ class AsyncIOExecutor(BaseExecutor):
 
         if iscoroutinefunction(job.func):
             if run_coroutine_job is not None:
-                coro = run_coroutine_job(job, job._jobstore_alias, run_times, self._logger.name)
+                coro = run_coroutine_job(job, self._logger.name, job_submission_id, run_time)
                 f = self._eventloop.create_task(coro)
             else:
                 raise Exception('Executing coroutine based jobs is not supported with Trollius')
         else:
-            f = self._eventloop.run_in_executor(None, run_job_func, job, job._jobstore_alias, run_times,
-                                                self._logger.name)
+            f = self._eventloop.run_in_executor(None, run_job, job, self._logger.name,
+                                               job_submission_id, run_time)
 
         f.add_done_callback(callback)

--- a/apscheduler/executors/asyncio.py
+++ b/apscheduler/executors/asyncio.py
@@ -29,8 +29,12 @@ class AsyncIOExecutor(BaseExecutor):
 
     def _do_submit_job(self, job, job_submission_id, run_time):
         def callback(f):
-            event = f.result()
-            self._handle_job_event(event)
+            try:
+                events = f.result()
+            except:
+                self._run_job_error(job.id, job_submission_id, job._jobstore_alias, *sys.exc_info()[1:])
+            else:
+                self._run_job_success(job.id, job_submission_id, job._jobstore_alias, events)
 
         if iscoroutinefunction(job.func):
             if run_coroutine_job is not None:

--- a/apscheduler/executors/base.py
+++ b/apscheduler/executors/base.py
@@ -10,12 +10,6 @@ import six
 
 from apscheduler.events import (
     JobExecutionEvent, EVENT_JOB_MISSED, EVENT_JOB_ERROR, EVENT_JOB_EXECUTED)
-try:
-    from inspect import iscoroutinefunction
-    from apscheduler.executors.base_py3 import generate_run_coroutine_job_closure
-except ImportError:
-    def iscoroutinefunction(func):
-        return False
 
 
 class MaxInstancesReachedError(Exception):
@@ -34,7 +28,7 @@ class BaseExecutor(six.with_metaclass(ABCMeta, object)):
 
     def __init__(self):
         super(BaseExecutor, self).__init__()
-        self._instances = defaultdict(lambda: [])
+        self._instances = defaultdict(lambda: 0)
 
     def start(self, scheduler, alias):
         """
@@ -58,117 +52,78 @@ class BaseExecutor(six.with_metaclass(ABCMeta, object)):
             have been executed
         """
 
-    def submit_job(self, job, run_times):
+    def submit_job(self, job, run_time):
         """
         Submits job for execution.
 
         :param Job job: job to execute
-        :param list[datetime] run_times: list of datetimes specifying
-            when the job should have been run
         :raises MaxInstancesReachedError: if the maximum number of
             allowed instances for this job has been reached
 
         """
         assert self._lock is not None, 'This executor has not been started yet'
         with self._lock:
-            if len(self._instances[job.id]) >= job.max_instances:
+            if self._instances[job.id] >= job.max_instances:
                 raise MaxInstancesReachedError(job)
-            self._prepare_job_submission(job, run_times)
 
-    def _prepare_job_submission(self, job, run_times):
-        # Add the job instance to the jobstore
-        job_submission_id = job._scheduler._jobstores[job._jobstore_alias].\
-                add_job_submission(job)
-        self._instances[job.id].append(job_submission_id)
-        if iscoroutinefunction(job.func):
-            self._do_submit_job(job,
-                                run_times,
-                                # Bind "job_submission_id" to "run_job()" in a closure
-                                generate_run_coroutine_job_closure(job_submission_id))
-        else:
-            self._do_submit_job(job,
-                                run_times,
-                                # Build the same closure, only return a coroutine
-                                generate_run_job_closure(job_submission_id))
+            job_submission_id = self._scheduler._add_job_submission(job)
+
+            self._do_submit_job(job, job_submission_id, run_time)
+            self._instances[job.id] += 1
 
     @abstractmethod
-    def _do_submit_job(self, job, run_times, run_job_func):
-        """
-        Performs the actual task of scheduling `run_job_func` to be called.
+    def _do_submit_job(self, job, job_submission_id, run_time):
+        """Performs the actual task of scheduling `run_job` to be called."""
 
-        :param run_job_func func|coroutine: The function or coroutine to be executed
-
-        """
-
-    def _run_job_success(self, job_id, job_instance_id, events):
+    def _run_job_success(self, job_id, events):
         """
         Called by the executor with the list of generated events when :func:`run_job` has been
         successfully called.
 
         """
         with self._lock:
-            self._instances[job_id].remove(job_instance_id)
-            if len(self._instances[job_id]) == 0:
+            self._instances[job_id] -= 1
+            if self._instances[job_id] == 0:
                 del self._instances[job_id]
-        self.update_job_submission(job_instance_id, state="success")
+
         for event in events:
             self._scheduler._dispatch_event(event)
 
-    def _run_job_error(self, job_id, exc, job_instance_id, traceback=None):
+    def _run_job_error(self, job_id, exc, traceback=None):
         """Called by the executor with the exception if there is an error  calling `run_job`."""
         with self._lock:
-            self._instances[job_id].remove(job_instance_id)
-            if len(self._instances[job_id]) == 0:
+            self._instances[job_id] -= 1
+            if self._instances[job_id] == 0:
                 del self._instances[job_id]
-        self.update_job_submission(job_instance_id, state="failure")
 
         exc_info = (exc.__class__, exc, traceback)
         self._logger.error('Error running job %s', job_id, exc_info=exc_info)
 
 
-def generate_run_job_closure(job_submission_id):
-    """ Generate a closure so that "run_job" can see 'job_submission_id' later """
-    def run_job(job, jobstore_alias, run_times, logger_name):
-        """
-        Called by executors to run the job. Returns a list of scheduler events to be
-        dispatched by the scheduler.
+def run_job(job, logger_name, job_submission_id, run_time):
+    """
+    Called by executors to run the job. Returns a list of scheduler events to be dispatched by the
+    scheduler.
 
-        """
-        events = []
-        logger = logging.getLogger(logger_name)
-        for run_time in run_times:
-            # See if the job missed its run time window, and handle
-            # possible misfires accordingly
-            if job.misfire_grace_time is not None:
-                difference = datetime.now(utc) - run_time
-                grace_time = timedelta(seconds=job.misfire_grace_time)
-                if difference > grace_time:
-                    events.append(JobExecutionEvent(EVENT_JOB_MISSED, job.id, jobstore_alias,
-                                                    run_time))
-                    logger.warning('Run time of job "%s" was missed by %s', job, difference)
-                    continue
+    """
+    events = []
+    logger = logging.getLogger(logger_name)
+    
+    job._scheduler._update_job_submission(job_submission_id, job._jobstore_alias, state='running')
+    logger.info('Running job "%s" (scheduled at %s)', job, run_time)
+    try:
+        retval = job.func(*job.args, **job.kwargs)
+    except:
+        exc, tb = sys.exc_info()[1:]
+        formatted_tb = ''.join(format_tb(tb))
+        events.append(JobExecutionEvent(EVENT_JOB_ERROR, job.id, job_submission_id, job.jobstore_alias, run_time,
+                                        exception=exc, traceback=formatted_tb))
+        job._scheduler._update_job_submission(job_submission_id, job._jobstore_alias, state='failure')
+        logger.exception('Job "%s" raised an exception', job)
+    else:
+        events.append(JobExecutionEvent(EVENT_JOB_EXECUTED, job.id, job_submission_id, job.jobstore_alias, run_time,
+                                        retval=retval))
+        job._scheduler._update_job_submission(job_submission_id, job._jobstore_alias, state='success')
+        logger.info('Job "%s" executed successfully', job)
 
-            logger.info('Running job "%s" (scheduled at %s)', job, run_time)
-            # Update the job submission to "running"
-            job._scheduler._jobstores[jobstore_alias].\
-                update_job_submission(job_submission_id, state="running")
-            try:
-                retval = job.func(*job.args, **job.kwargs)
-            except:
-                exc, tb = sys.exc_info()[1:]
-                formatted_tb = ''.join(format_tb(tb))
-                events.append(JobExecutionEvent(EVENT_JOB_ERROR, job.id, jobstore_alias, run_time,
-                                                exception=exc, traceback=formatted_tb))
-                logger.exception('Job "%s" raised an exception', job)
-                job._scheduler._jobstores[jobstore_alias].\
-                    update_job_submission(job_submission_id, state="failure")
-            else:
-                events.append(JobExecutionEvent(EVENT_JOB_EXECUTED, job.id, jobstore_alias,
-                                                run_time,
-                                                retval=retval))
-                logger.info('Job "%s" executed successfully', job)
-                job._scheduler._jobstores[jobstore_alias].\
-                    update_job_submission(job_submission_id, state="success")
-
-        return events
-    return run_job
+    return events

--- a/apscheduler/executors/base.py
+++ b/apscheduler/executors/base.py
@@ -12,6 +12,7 @@ from apscheduler.events import (
     JobExecutionEvent, EVENT_JOB_MISSED, EVENT_JOB_ERROR, EVENT_JOB_EXECUTED)
 
 
+
 class MaxInstancesReachedError(Exception):
     def __init__(self, job):
         super(MaxInstancesReachedError, self).__init__(
@@ -28,7 +29,7 @@ class BaseExecutor(six.with_metaclass(ABCMeta, object)):
 
     def __init__(self):
         super(BaseExecutor, self).__init__()
-        self._instances = defaultdict(lambda: 0)
+        self._instances = defaultdict(lambda: [])
 
     def start(self, scheduler, alias):
         """
@@ -65,73 +66,93 @@ class BaseExecutor(six.with_metaclass(ABCMeta, object)):
         """
         assert self._lock is not None, 'This executor has not been started yet'
         with self._lock:
-            if self._instances[job.id] >= job.max_instances:
+            if len(self._instances[job.id]) >= job.max_instances:
                 raise MaxInstancesReachedError(job)
+            self._prepare_submit_job(job, run_times)
 
-            self._do_submit_job(job, run_times)
-            self._instances[job.id] += 1
+    def _do_prepare_submit_job(self, job, run_times):
+        # Add the job instance to the jobstore
+        job_submission_id = job._scheduler.jobstores[jobstore_alias].\
+                add_job_submission(job)
+        self._instances[job.id].append(job_submission_id)
+        self._do_submit_job(job, 
+                            run_times, 
+                            # Bind "job_submission_id" to "run_job()" in a closure
+                            generate_run_job_closure(job_submission_id))
+        
 
     @abstractmethod
-    def _do_submit_job(self, job, run_times):
-        """Performs the actual task of scheduling `run_job` to be called."""
+    def _do_submit_job(self, job, run_times, run_job_func, run_job_coroutine_func):
+        """Performs the actual task of scheduling `run_job_func` to be called."""
+        
 
-    def _run_job_success(self, job_id, events):
+    def _run_job_success(self, job_id, job_instance_id, events):
         """
         Called by the executor with the list of generated events when :func:`run_job` has been
         successfully called.
 
         """
         with self._lock:
-            self._instances[job_id] -= 1
-            if self._instances[job_id] == 0:
+            self._instances[job_id].remove(job_instance_id)
+            if len(self._instances[job_id]) == 0:
                 del self._instances[job_id]
-
+        self.update_job_submission(job_instance_id, status="success")
         for event in events:
             self._scheduler._dispatch_event(event)
 
-    def _run_job_error(self, job_id, exc, traceback=None):
+    def _run_job_error(self, job_id, exc, job_instance_id, traceback=None):
         """Called by the executor with the exception if there is an error  calling `run_job`."""
         with self._lock:
-            self._instances[job_id] -= 1
-            if self._instances[job_id] == 0:
+            self._instances[job_id].remove(job_instance_id)
+            if len(self._instances[job_id]) == 0:
                 del self._instances[job_id]
+        self.update_job_submission(job_instance_id, status="failure")
 
         exc_info = (exc.__class__, exc, traceback)
         self._logger.error('Error running job %s', job_id, exc_info=exc_info)
 
+def generate_run_job_closure(job_submission_id):
+    """ Generate a closure so that "run_job" can see 'job_submission_id' later """ 
+    def run_job(job, jobstore_alias, run_times, logger_name):
+        """
+        Called by executors to run the job. Returns a list of scheduler events to be dispatched by the
+        scheduler.
 
-def run_job(job, jobstore_alias, run_times, logger_name):
-    """
-    Called by executors to run the job. Returns a list of scheduler events to be dispatched by the
-    scheduler.
+        """
+        events = []
+        logger = logging.getLogger(logger_name)
+        for run_time in run_times:
+            # See if the job missed its run time window, and handle
+            # possible misfires accordingly
+            if job.misfire_grace_time is not None:
+                difference = datetime.now(utc) - run_time
+                grace_time = timedelta(seconds=job.misfire_grace_time)
+                if difference > grace_time:
+                    events.append(JobExecutionEvent(EVENT_JOB_MISSED, job.id, jobstore_alias,
+                                                    run_time))
+                    logger.warning('Run time of job "%s" was missed by %s', job, difference)
+                    continue
+            
+            logger.info('Running job "%s" (scheduled at %s)', job, run_time)
+            # Update the job submission to "running"
+            job._scheduler.jobstores[jobstore_alias].\
+                    update_job_submission(job_submission_id, status="running")
+            try:
+                retval = job.func(*job.args, **job.kwargs)
+            except:
+                exc, tb = sys.exc_info()[1:]
+                formatted_tb = ''.join(format_tb(tb))
+                events.append(JobExecutionEvent(EVENT_JOB_ERROR, job.id, jobstore_alias, run_time,
+                                                exception=exc, traceback=formatted_tb))
+                logger.exception('Job "%s" raised an exception', job)
+                job._scheduler.jobstores[jobstore_alias].\
+                        update_job_submission(job_submission_id, status="failure")
+            else:
+                events.append(JobExecutionEvent(EVENT_JOB_EXECUTED, job.id, jobstore_alias, run_time,
+                                                retval=retval))
+                logger.info('Job "%s" executed successfully', job)
+                job._scheduler.jobstores[jobstore_alias].\
+                        update_job_submission(job_submission_id, status="success")
 
-    """
-    events = []
-    logger = logging.getLogger(logger_name)
-    for run_time in run_times:
-        # See if the job missed its run time window, and handle
-        # possible misfires accordingly
-        if job.misfire_grace_time is not None:
-            difference = datetime.now(utc) - run_time
-            grace_time = timedelta(seconds=job.misfire_grace_time)
-            if difference > grace_time:
-                events.append(JobExecutionEvent(EVENT_JOB_MISSED, job.id, jobstore_alias,
-                                                run_time))
-                logger.warning('Run time of job "%s" was missed by %s', job, difference)
-                continue
-
-        logger.info('Running job "%s" (scheduled at %s)', job, run_time)
-        try:
-            retval = job.func(*job.args, **job.kwargs)
-        except:
-            exc, tb = sys.exc_info()[1:]
-            formatted_tb = ''.join(format_tb(tb))
-            events.append(JobExecutionEvent(EVENT_JOB_ERROR, job.id, jobstore_alias, run_time,
-                                            exception=exc, traceback=formatted_tb))
-            logger.exception('Job "%s" raised an exception', job)
-        else:
-            events.append(JobExecutionEvent(EVENT_JOB_EXECUTED, job.id, jobstore_alias, run_time,
-                                            retval=retval))
-            logger.info('Job "%s" executed successfully', job)
-
-    return events
+        return events
+    return run_job

--- a/apscheduler/executors/base.py
+++ b/apscheduler/executors/base.py
@@ -66,42 +66,48 @@ class BaseExecutor(six.with_metaclass(ABCMeta, object)):
             if self._instances[job.id] >= job.max_instances:
                 raise MaxInstancesReachedError(job)
             job_submission_id = self._scheduler._add_job_submission(job)
-            self._do_submit_job(job, job_submission_id, run_time)
             self._instances[job.id] += 1
+            self._do_submit_job(job, job_submission_id, run_time)
 
     @abstractmethod
     def _do_submit_job(self, job, job_submission_id, run_time):
         """Performs the actual task of scheduling `run_job` to be called."""
 
-    def _run_job_success(self, job_id, job_submission_id, jobstore_alias, events):
+    def _handle_job_event(self, event):
+        if event.code == EVENT_JOB_ERROR:
+            self._run_job_error(event)
+        elif event.code == EVENT_JOB_EXECUTION:
+            self._run_job_success(event)
+
+    def _run_job_success(self, event):
         """
         Called by the executor with the list of generated events when :func:`run_job` has been
         successfully called.
 
         """
         with self._lock:
-            self._instances[job_id] -= 1
-            if self._instances[job_id] == 0:
-                del self._instances[job_id]
+            self._instances[event.job_id] -= 1
+            if self._instances[event.job_id] == 0:
+                del self._instances[event.job_id]
 
-        for event in events:
-            self._scheduler._dispatch_event(event)
+        self._scheduler._dispatch_event(event)
+        
         now = datetime.now(self._scheduler.timezone)
-        self._scheduler._update_job_submission(job_submission_id, jobstore_alias,
+        self._scheduler._update_job_submission(event.job_submission_id, event.jobstore,
                                                completed_at=now, state='success')
 
-    def _run_job_error(self, job_id, job_submission_id, jobstore_alias, exc, traceback=None):
+    def _run_job_error(self, event):
         """Called by the executor with the exception if there is an error  calling `run_job`."""
         with self._lock:
-            self._instances[job_id] -= 1
-            if self._instances[job_id] == 0:
-                del self._instances[job_id]
+            self._instances[event.job_id] -= 1
+            if self._instances[event.job_id] == 0:
+                del self._instances[event.job_id]
 
         now = datetime.now(self._scheduler.timezone)
-        self._scheduler._update_job_submission(job_submission_id, jobstore_alias,
+        self._scheduler._update_job_submission(event.job_submission_id, event.jobstore,
                                                state='failure', completed_at=now)
-        exc_info = (exc.__class__, exc, traceback)
-        self._logger.error('Error running job %s', job_id, exc_info=exc_info)
+        exc_info = (exc.__class__, event.exception, event.traceback)
+        self._logger.error('Error running job %s', event.job_id, exc_info=exc_info)
 
 
 def run_job(job, logger_name, job_submission_id, jobstore_alias, run_time):
@@ -110,21 +116,29 @@ def run_job(job, logger_name, job_submission_id, jobstore_alias, run_time):
     scheduler.
 
     """
-    events = []
+    event = None
     logger = logging.getLogger(logger_name)
-    #jobstore.update_job_submission(job_submission_id, job._jobstore_alias, state='running')
+    
     logger.info('Running job "%s" (scheduled at %s)', job, run_time)
     try:
         retval = job.func(*job.args, **job.kwargs)
     except:
         exc, tb = sys.exc_info()[1:]
         formatted_tb = ''.join(format_tb(tb))
-        events.append(JobExecutionEvent(EVENT_JOB_ERROR, job.id, jobstore_alias, run_time,
-                                        job_submission_id, exception=exc, traceback=formatted_tb))
+        # TODO: This event is never dispatched! Perhaps instead of re-raising an exception,
+        # we can JUST return events w/ the exception's exc & traceback. In every executor,
+        # we check to see if f.exc is not None (future). If it is not None, we call 
+        # _run_job_error, the problem is we must choose between raising an exception below,
+        # or returning the EVENT_JOB_ERROR. Perhaps we should JUST return the events[], and
+        # check the event type to determine which function to call.
+        event = JobExecutionEvent(EVENT_JOB_ERROR, job.id, jobstore_alias, run_time,
+                                        job_submission_id, exception=exc, traceback=formatted_tb)
         logger.exception('Job "%s" raised an exception', job)
+        # Need to re-raise the exception
+        
     else:
-        events.append(JobExecutionEvent(EVENT_JOB_EXECUTED, job.id, jobstore_alias, run_time,
-                                        job_submission_id, retval=retval))
+        event = JobExecutionEvent(EVENT_JOB_EXECUTED, job.id, jobstore_alias, run_time,
+                                        job_submission_id, retval=retval)
         logger.info('Job "%s" executed successfully', job)
 
-    return events
+    return event

--- a/apscheduler/executors/base.py
+++ b/apscheduler/executors/base.py
@@ -66,48 +66,42 @@ class BaseExecutor(six.with_metaclass(ABCMeta, object)):
             if self._instances[job.id] >= job.max_instances:
                 raise MaxInstancesReachedError(job)
             job_submission_id = self._scheduler._add_job_submission(job)
-            self._instances[job.id] += 1
             self._do_submit_job(job, job_submission_id, run_time)
+            self._instances[job.id] += 1
 
     @abstractmethod
     def _do_submit_job(self, job, job_submission_id, run_time):
         """Performs the actual task of scheduling `run_job` to be called."""
 
-    def _handle_job_event(self, event):
-        if event.code == EVENT_JOB_ERROR:
-            self._run_job_error(event)
-        elif event.code == EVENT_JOB_EXECUTION:
-            self._run_job_success(event)
-
-    def _run_job_success(self, event):
+    def _run_job_success(self, job_id, job_submission_id, jobstore_alias, events):
         """
         Called by the executor with the list of generated events when :func:`run_job` has been
         successfully called.
 
         """
         with self._lock:
-            self._instances[event.job_id] -= 1
-            if self._instances[event.job_id] == 0:
-                del self._instances[event.job_id]
+            self._instances[job_id] -= 1
+            if self._instances[job_id] == 0:
+                del self._instances[job_id]
 
-        self._scheduler._dispatch_event(event)
-        
+        for event in events:
+            self._scheduler._dispatch_event(event)
         now = datetime.now(self._scheduler.timezone)
-        self._scheduler._update_job_submission(event.job_submission_id, event.jobstore,
+        self._scheduler._update_job_submission(job_submission_id, jobstore_alias,
                                                completed_at=now, state='success')
 
-    def _run_job_error(self, event):
+    def _run_job_error(self, job_id, job_submission_id, jobstore_alias, exc, traceback=None):
         """Called by the executor with the exception if there is an error  calling `run_job`."""
         with self._lock:
-            self._instances[event.job_id] -= 1
-            if self._instances[event.job_id] == 0:
-                del self._instances[event.job_id]
+            self._instances[job_id] -= 1
+            if self._instances[job_id] == 0:
+                del self._instances[job_id]
 
         now = datetime.now(self._scheduler.timezone)
-        self._scheduler._update_job_submission(event.job_submission_id, event.jobstore,
+        self._scheduler._update_job_submission(job_submission_id, jobstore_alias,
                                                state='failure', completed_at=now)
-        exc_info = (exc.__class__, event.exception, event.traceback)
-        self._logger.error('Error running job %s', event.job_id, exc_info=exc_info)
+        exc_info = (exc.__class__, exc, traceback)
+        self._logger.error('Error running job %s', job_id, exc_info=exc_info)
 
 
 def run_job(job, logger_name, job_submission_id, jobstore_alias, run_time):
@@ -116,29 +110,21 @@ def run_job(job, logger_name, job_submission_id, jobstore_alias, run_time):
     scheduler.
 
     """
-    event = None
+    events = []
     logger = logging.getLogger(logger_name)
-    
+    #jobstore.update_job_submission(job_submission_id, job._jobstore_alias, state='running')
     logger.info('Running job "%s" (scheduled at %s)', job, run_time)
     try:
         retval = job.func(*job.args, **job.kwargs)
     except:
         exc, tb = sys.exc_info()[1:]
         formatted_tb = ''.join(format_tb(tb))
-        # TODO: This event is never dispatched! Perhaps instead of re-raising an exception,
-        # we can JUST return events w/ the exception's exc & traceback. In every executor,
-        # we check to see if f.exc is not None (future). If it is not None, we call 
-        # _run_job_error, the problem is we must choose between raising an exception below,
-        # or returning the EVENT_JOB_ERROR. Perhaps we should JUST return the events[], and
-        # check the event type to determine which function to call.
-        event = JobExecutionEvent(EVENT_JOB_ERROR, job.id, jobstore_alias, run_time,
-                                        job_submission_id, exception=exc, traceback=formatted_tb)
+        events.append(JobExecutionEvent(EVENT_JOB_ERROR, job.id, jobstore_alias, run_time,
+                                        job_submission_id, exception=exc, traceback=formatted_tb))
         logger.exception('Job "%s" raised an exception', job)
-        # Need to re-raise the exception
-        
     else:
-        event = JobExecutionEvent(EVENT_JOB_EXECUTED, job.id, jobstore_alias, run_time,
-                                        job_submission_id, retval=retval)
+        events.append(JobExecutionEvent(EVENT_JOB_EXECUTED, job.id, jobstore_alias, run_time,
+                                        job_submission_id, retval=retval))
         logger.info('Job "%s" executed successfully', job)
 
-    return event
+    return events

--- a/apscheduler/executors/base.py
+++ b/apscheduler/executors/base.py
@@ -1,15 +1,14 @@
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
-from datetime import datetime, timedelta
+from datetime import datetime
 from traceback import format_tb
 import logging
 import sys
 
-from pytz import utc
 import six
 
 from apscheduler.events import (
-    JobExecutionEvent, EVENT_JOB_MISSED, EVENT_JOB_ERROR, EVENT_JOB_EXECUTED)
+    JobExecutionEvent, EVENT_JOB_ERROR, EVENT_JOB_EXECUTED)
 
 
 class MaxInstancesReachedError(Exception):
@@ -112,7 +111,6 @@ def run_job(job, logger_name, job_submission_id, jobstore_alias, run_time):
     """
     events = []
     logger = logging.getLogger(logger_name)
-    #jobstore.update_job_submission(job_submission_id, job._jobstore_alias, state='running')
     logger.info('Running job "%s" (scheduled at %s)', job, run_time)
     try:
         retval = job.func(*job.args, **job.kwargs)

--- a/apscheduler/executors/base_py3.py
+++ b/apscheduler/executors/base_py3.py
@@ -9,33 +9,39 @@ from apscheduler.events import (
     JobExecutionEvent, EVENT_JOB_MISSED, EVENT_JOB_ERROR, EVENT_JOB_EXECUTED)
 
 
-async def run_coroutine_job(job, jobstore_alias, run_times, logger_name):
-    """Coroutine version of run_job()."""
-    events = []
-    logger = logging.getLogger(logger_name)
-    for run_time in run_times:
-        # See if the job missed its run time window, and handle possible misfires accordingly
-        if job.misfire_grace_time is not None:
-            difference = datetime.now(utc) - run_time
-            grace_time = timedelta(seconds=job.misfire_grace_time)
-            if difference > grace_time:
-                events.append(JobExecutionEvent(EVENT_JOB_MISSED, job.id, jobstore_alias,
-                                                run_time))
-                logger.warning('Run time of job "%s" was missed by %s', job, difference)
-                continue
+def generate_run_coroutine_job_closure(job_submission_id):
+    async def run_coroutine_job(job, jobstore_alias, run_times, logger_name):
+        """Coroutine version of run_job()."""
+        events = []
+        logger = logging.getLogger(logger_name)
+        for run_time in run_times:
+            # See if the job missed its run time window, and handle possible misfires accordingly
+            if job.misfire_grace_time is not None:
+                difference = datetime.now(utc) - run_time
+                grace_time = timedelta(seconds=job.misfire_grace_time)
+                if difference > grace_time:
+                    events.append(JobExecutionEvent(EVENT_JOB_MISSED, job.id, jobstore_alias,
+                                                    run_time))
+                    logger.warning('Run time of job "%s" was missed by %s', job, difference)
+                    continue
 
-        logger.info('Running job "%s" (scheduled at %s)', job, run_time)
-        try:
-            retval = await job.func(*job.args, **job.kwargs)
-        except:
-            exc, tb = sys.exc_info()[1:]
-            formatted_tb = ''.join(format_tb(tb))
-            events.append(JobExecutionEvent(EVENT_JOB_ERROR, job.id, jobstore_alias, run_time,
-                                            exception=exc, traceback=formatted_tb))
-            logger.exception('Job "%s" raised an exception', job)
-        else:
-            events.append(JobExecutionEvent(EVENT_JOB_EXECUTED, job.id, jobstore_alias, run_time,
-                                            retval=retval))
-            logger.info('Job "%s" executed successfully', job)
+            logger.info('Running job "%s" (scheduled at %s)', job, run_time)
+            try:
+                retval = await job.func(*job.args, **job.kwargs)
+            except:
+                exc, tb = sys.exc_info()[1:]
+                formatted_tb = ''.join(format_tb(tb))
+                events.append(JobExecutionEvent(EVENT_JOB_ERROR, job.id, jobstore_alias, run_time,
+                                                exception=exc, traceback=formatted_tb))
+                job._scheduler.jobstores[jobstore_alias].\
+                        update_job_submission(job_submission_id, status="failure")
+                logger.exception('Job "%s" raised an exception', job)
+            else:
+                events.append(JobExecutionEvent(EVENT_JOB_EXECUTED, job.id, jobstore_alias, run_time,
+                                                retval=retval))
+                logger.info('Job "%s" executed successfully', job)
+                job._scheduler.jobstores[jobstore_alias].\
+                        update_job_submission(job_submission_id, status="success")
 
-    return events
+        return events
+    return run_coroutine_job

--- a/apscheduler/executors/base_py3.py
+++ b/apscheduler/executors/base_py3.py
@@ -1,12 +1,10 @@
 import logging
 import sys
-from datetime import datetime, timedelta
 from traceback import format_tb
 
-from pytz import utc
 
 from apscheduler.events import (
-    JobExecutionEvent, EVENT_JOB_MISSED, EVENT_JOB_ERROR, EVENT_JOB_EXECUTED)
+    JobExecutionEvent, EVENT_JOB_ERROR, EVENT_JOB_EXECUTED)
 
 
 async def run_coroutine_job(job, logger_name, job_submission_id, jobstore_alias, run_time):

--- a/apscheduler/executors/base_py3.py
+++ b/apscheduler/executors/base_py3.py
@@ -9,7 +9,7 @@ from apscheduler.events import (
     JobExecutionEvent, EVENT_JOB_MISSED, EVENT_JOB_ERROR, EVENT_JOB_EXECUTED)
 
 
-async def run_coroutine_job(job, logger_name. job_submission_id, run_time):
+async def run_coroutine_job(job, logger_name, job_submission_id, jobstore_alias, run_time):
     """Coroutine version of run_job()."""
     """
     Called by executors to run the job. Returns a list of scheduler events to be dispatched by the
@@ -19,21 +19,19 @@ async def run_coroutine_job(job, logger_name. job_submission_id, run_time):
     events = []
     logger = logging.getLogger(logger_name)
     
-    job._scheduler._update_job_submission(job_submission_id, job._jobstore_alias, state='running')
+    #job._scheduler._update_job_submission(job_submission_id, job._jobstore_alias, state='running')
     logger.info('Running job "%s" (scheduled at %s)', job, run_time)
     try:
         retval = job.func(*job.args, **job.kwargs)
     except:
         exc, tb = sys.exc_info()[1:]
         formatted_tb = ''.join(format_tb(tb))
-        events.append(JobExecutionEvent(EVENT_JOB_ERROR, job.id, job.jobstore_alias, run_time,
+        events.append(JobExecutionEvent(EVENT_JOB_ERROR, job.id, jobstore_alias, run_time,
                                         exception=exc, traceback=formatted_tb))
-        job._scheduler._update_job_submission(job_submission_id, job._jobstore_alias, state='failure')
         logger.exception('Job "%s" raised an exception', job)
     else:
-        events.append(JobExecutionEvent(EVENT_JOB_EXECUTED, job.id, job.jobstore_alias, run_time,
+        events.append(JobExecutionEvent(EVENT_JOB_EXECUTED, job.id, jobstore_alias, run_time,
                                         retval=retval))
-        job._scheduler._update_job_submission(job_submission_id, job._jobstore_alias, state='success')
         logger.info('Job "%s" executed successfully', job)
 
     return events

--- a/apscheduler/executors/base_py3.py
+++ b/apscheduler/executors/base_py3.py
@@ -22,7 +22,7 @@ async def run_coroutine_job(job, logger_name, job_submission_id, jobstore_alias,
     #job._scheduler._update_job_submission(job_submission_id, job._jobstore_alias, state='running')
     logger.info('Running job "%s" (scheduled at %s)', job, run_time)
     try:
-        retval = job.func(*job.args, **job.kwargs)
+        retval = await job.func(*job.args, **job.kwargs)
     except:
         exc, tb = sys.exc_info()[1:]
         formatted_tb = ''.join(format_tb(tb))

--- a/apscheduler/executors/base_py3.py
+++ b/apscheduler/executors/base_py3.py
@@ -18,9 +18,7 @@ async def run_coroutine_job(job, logger_name, job_submission_id, jobstore_alias,
     """
     events = []
     logger = logging.getLogger(logger_name)
-    
-    #job._scheduler._update_job_submission(job_submission_id, job._jobstore_alias, state='running')
-    logger.info('Running job "%s" (scheduled at %s)', job, run_time)
+
     try:
         retval = await job.func(*job.args, **job.kwargs)
     except:

--- a/apscheduler/executors/base_py3.py
+++ b/apscheduler/executors/base_py3.py
@@ -9,54 +9,31 @@ from apscheduler.events import (
     JobExecutionEvent, EVENT_JOB_MISSED, EVENT_JOB_ERROR, EVENT_JOB_EXECUTED)
 
 
-def generate_run_coroutine_job_closure(job_submission_id):
-    async def run_coroutine_job(job, jobstore_alias, run_times, logger_name):
-        """Coroutine version of run_job()."""
-        events = []
-        logger = logging.getLogger(logger_name)
-        for run_time in run_times:
-            # See if the job missed its run time window, and handle
-            # possible misfires accordingly
-            if job.misfire_grace_time is not None:
-                difference = datetime.now(utc) - run_time
-                grace_time = timedelta(seconds=job.misfire_grace_time)
-                if difference > grace_time:
-                    events.append(JobExecutionEvent(EVENT_JOB_MISSED, job.id, jobstore_alias,
-                                                    run_time))
-                    logger.warning('Run time of job "%s" was missed by %s', job, difference)
-                    continue
+async def run_coroutine_job(job, logger_name. job_submission_id, run_time):
+    """Coroutine version of run_job()."""
+    """
+    Called by executors to run the job. Returns a list of scheduler events to be dispatched by the
+    scheduler.
 
-            logger.info('Running job "%s" (scheduled at %s)', job, run_time)
-            # Update the job submission to "running"
-            job._scheduler._jobstores[jobstore_alias].\
-                update_job_submission(job_submission_id, state="running")
-            try:
-                retval = job.func(*job.args, **job.kwargs)
-            except:
-                exc, tb = sys.exc_info()[1:]
-                formatted_tb = ''.join(format_tb(tb))
-                events.append(JobExecutionEvent(EVENT_JOB_ERROR, job.id, jobstore_alias, run_time,
-                                                exception=exc, traceback=formatted_tb))
-                logger.exception('Job "%s" raised an exception', job)
-                with job.executor._lock:
-                    job.executor._instances[job.id].remove(job_submission_id)
-                    if len(job.executor._instances[job.id]) == 0:
-                        del job.executor._instances[job_id]
-                job._scheduler._jobstores[jobstore_alias].\
-                    update_job_submission(job_submission_id, state="failure")
-            else:
-                with job.executor._lock:
-                    job.executor._instances[job.id].remove(job_submission_id)
-                    if len(job.executor._instances[job.id]) == 0:
-                        del job.executor._instances[job.id]
-                        events.append(JobExecutionEvent(EVENT_JOB_EXECUTED,
-                                                        job.id,
-                                                        jobstore_alias,
-                                                        run_time,
-                                                        retval=retval))
-                logger.info('Job "%s" executed successfully', job)
-                job._scheduler._jobstores[jobstore_alias].\
-                    update_job_submission(job_submission_id, state="success")
+    """
+    events = []
+    logger = logging.getLogger(logger_name)
+    
+    job._scheduler._update_job_submission(job_submission_id, job._jobstore_alias, state='running')
+    logger.info('Running job "%s" (scheduled at %s)', job, run_time)
+    try:
+        retval = job.func(*job.args, **job.kwargs)
+    except:
+        exc, tb = sys.exc_info()[1:]
+        formatted_tb = ''.join(format_tb(tb))
+        events.append(JobExecutionEvent(EVENT_JOB_ERROR, job.id, job.jobstore_alias, run_time,
+                                        exception=exc, traceback=formatted_tb))
+        job._scheduler._update_job_submission(job_submission_id, job._jobstore_alias, state='failure')
+        logger.exception('Job "%s" raised an exception', job)
+    else:
+        events.append(JobExecutionEvent(EVENT_JOB_EXECUTED, job.id, job.jobstore_alias, run_time,
+                                        retval=retval))
+        job._scheduler._update_job_submission(job_submission_id, job._jobstore_alias, state='success')
+        logger.info('Job "%s" executed successfully', job)
 
-        return events
-    return run_coroutine_job
+    return events

--- a/apscheduler/executors/debug.py
+++ b/apscheduler/executors/debug.py
@@ -12,9 +12,5 @@ class DebugExecutor(BaseExecutor):
     """
 
     def _do_submit_job(self, job, job_submission_id, run_time):
-        try:
-            events = run_job(job, self._logger.name, job_submission_id, job._jobstore_alias,run_time)
-        except:
-            self._run_job_error(job.id, job_submission_id, job._jobstore_alias, *sys.exc_info()[1:])
-        else:
-            self._run_job_success(job.id, job_submission_id, job._jobstore_alias, events)
+        event = run_job(job, self._logger.name, job_submission_id, job._jobstore_alias,run_time)
+        self._handle_job_event(event)

--- a/apscheduler/executors/debug.py
+++ b/apscheduler/executors/debug.py
@@ -12,5 +12,9 @@ class DebugExecutor(BaseExecutor):
     """
 
     def _do_submit_job(self, job, job_submission_id, run_time):
-        event = run_job(job, self._logger.name, job_submission_id, job._jobstore_alias,run_time)
-        self._handle_job_event(event)
+        try:
+            events = run_job(job, self._logger.name, job_submission_id, job._jobstore_alias,run_time)
+        except:
+            self._run_job_error(job.id, job_submission_id, job._jobstore_alias, *sys.exc_info()[1:])
+        else:
+            self._run_job_success(job.id, job_submission_id, job._jobstore_alias, events)

--- a/apscheduler/executors/debug.py
+++ b/apscheduler/executors/debug.py
@@ -1,6 +1,6 @@
 import sys
 
-from apscheduler.executors.base import BaseExecutor, run_job
+from apscheduler.executors.base import BaseExecutor
 
 
 class DebugExecutor(BaseExecutor):
@@ -11,9 +11,9 @@ class DebugExecutor(BaseExecutor):
     Plugin alias: ``debug``
     """
 
-    def _do_submit_job(self, job, run_times):
+    def _do_submit_job(self, job, run_times, run_job_func):
         try:
-            events = run_job(job, job._jobstore_alias, run_times, self._logger.name)
+            events = run_job_func(job, job._jobstore_alias, run_times, self._logger.name)
         except:
             self._run_job_error(job.id, *sys.exc_info()[1:])
         else:

--- a/apscheduler/executors/debug.py
+++ b/apscheduler/executors/debug.py
@@ -13,8 +13,10 @@ class DebugExecutor(BaseExecutor):
 
     def _do_submit_job(self, job, job_submission_id, run_time):
         try:
-            events = run_job(job, self._logger.name, job_submission_id, job._jobstore_alias,run_time)
+            events = run_job(job, self._logger.name, job_submission_id, job._jobstore_alias,
+                             run_time)
         except:
-            self._run_job_error(job.id, job_submission_id, job._jobstore_alias, *sys.exc_info()[1:])
+            self._run_job_error(job.id, job_submission_id, job._jobstore_alias,
+                                *sys.exc_info()[1:])
         else:
             self._run_job_success(job.id, job_submission_id, job._jobstore_alias, events)

--- a/apscheduler/executors/debug.py
+++ b/apscheduler/executors/debug.py
@@ -1,6 +1,6 @@
 import sys
 
-from apscheduler.executors.base import BaseExecutor
+from apscheduler.executors.base import BaseExecutor, run_job
 
 
 class DebugExecutor(BaseExecutor):
@@ -11,9 +11,9 @@ class DebugExecutor(BaseExecutor):
     Plugin alias: ``debug``
     """
 
-    def _do_submit_job(self, job, run_times, run_job_func):
+    def _do_submit_job(self, job, job_submission_id, run_time):
         try:
-            events = run_job_func(job, job._jobstore_alias, run_times, self._logger.name)
+            events = run_job(job, self._logger.name, job_submission_id, run_time)
         except:
             self._run_job_error(job.id, *sys.exc_info()[1:])
         else:

--- a/apscheduler/executors/debug.py
+++ b/apscheduler/executors/debug.py
@@ -13,8 +13,8 @@ class DebugExecutor(BaseExecutor):
 
     def _do_submit_job(self, job, job_submission_id, run_time):
         try:
-            events = run_job(job, self._logger.name, job_submission_id, run_time)
+            events = run_job(job, self._logger.name, job_submission_id, job._jobstore_alias,run_time)
         except:
-            self._run_job_error(job.id, *sys.exc_info()[1:])
+            self._run_job_error(job.id, job_submission_id, job._jobstore_alias, *sys.exc_info()[1:])
         else:
-            self._run_job_success(job.id, events)
+            self._run_job_success(job.id, job_submission_id, job._jobstore_alias, events)

--- a/apscheduler/executors/gevent.py
+++ b/apscheduler/executors/gevent.py
@@ -19,12 +19,8 @@ class GeventExecutor(BaseExecutor):
 
     def _do_submit_job(self, job, job_submission_id, run_time):
         def callback(greenlet):
-            try:
-                events = greenlet.get()
-            except:
-                self._run_job_error(job.id, job_submission_id, job._jobstore_alias, *sys.exc_info()[1:])
-            else:
-                self._run_job_success(job.id, job_submission_id, job._jobstore_alias, events)
+            event = greenlet.get()
+            self._handle_job_event(event)
 
         gevent.spawn(run_job, job, self._logger.name, job_submission_id, job._jobstore_alias, run_time).\
             link(callback)

--- a/apscheduler/executors/gevent.py
+++ b/apscheduler/executors/gevent.py
@@ -22,9 +22,10 @@ class GeventExecutor(BaseExecutor):
             try:
                 events = greenlet.get()
             except:
-                self._run_job_error(job.id, job_submission_id, job._jobstore_alias, *sys.exc_info()[1:])
+                self._run_job_error(job.id, job_submission_id, job._jobstore_alias,
+                                    *sys.exc_info()[1:])
             else:
                 self._run_job_success(job.id, job_submission_id, job._jobstore_alias, events)
 
-        gevent.spawn(run_job, job, self._logger.name, job_submission_id, job._jobstore_alias, run_time).\
-            link(callback)
+        gevent.spawn(run_job, job, self._logger.name, job_submission_id,
+                     job._jobstore_alias, run_time).link(callback)

--- a/apscheduler/executors/gevent.py
+++ b/apscheduler/executors/gevent.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 import sys
 
-from apscheduler.executors.base import BaseExecutor
+from apscheduler.executors.base import BaseExecutor, run_job
 
 
 try:
@@ -17,7 +17,7 @@ class GeventExecutor(BaseExecutor):
     Plugin alias: ``gevent``
     """
 
-    def _do_submit_job(self, job, run_times, run_job_func):
+    def _do_submit_job(self, job, job_submission_id, run_time):
         def callback(greenlet):
             try:
                 events = greenlet.get()
@@ -26,5 +26,5 @@ class GeventExecutor(BaseExecutor):
             else:
                 self._run_job_success(job.id, events)
 
-        gevent.spawn(run_job_func, job, job._jobstore_alias, run_times, self._logger.name).\
+        gevent.spawn(run_job, job, self._logger.name, job_submission_id, run_time).\
             link(callback)

--- a/apscheduler/executors/gevent.py
+++ b/apscheduler/executors/gevent.py
@@ -19,8 +19,12 @@ class GeventExecutor(BaseExecutor):
 
     def _do_submit_job(self, job, job_submission_id, run_time):
         def callback(greenlet):
-            event = greenlet.get()
-            self._handle_job_event(event)
+            try:
+                events = greenlet.get()
+            except:
+                self._run_job_error(job.id, job_submission_id, job._jobstore_alias, *sys.exc_info()[1:])
+            else:
+                self._run_job_success(job.id, job_submission_id, job._jobstore_alias, events)
 
         gevent.spawn(run_job, job, self._logger.name, job_submission_id, job._jobstore_alias, run_time).\
             link(callback)

--- a/apscheduler/executors/gevent.py
+++ b/apscheduler/executors/gevent.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 import sys
 
-from apscheduler.executors.base import BaseExecutor, run_job
+from apscheduler.executors.base import BaseExecutor
 
 
 try:
@@ -17,7 +17,7 @@ class GeventExecutor(BaseExecutor):
     Plugin alias: ``gevent``
     """
 
-    def _do_submit_job(self, job, run_times):
+    def _do_submit_job(self, job, run_times, run_job_func):
         def callback(greenlet):
             try:
                 events = greenlet.get()
@@ -26,5 +26,5 @@ class GeventExecutor(BaseExecutor):
             else:
                 self._run_job_success(job.id, events)
 
-        gevent.spawn(run_job, job, job._jobstore_alias, run_times, self._logger.name).\
+        gevent.spawn(run_job_func, job, job._jobstore_alias, run_times, self._logger.name).\
             link(callback)

--- a/apscheduler/executors/gevent.py
+++ b/apscheduler/executors/gevent.py
@@ -22,9 +22,9 @@ class GeventExecutor(BaseExecutor):
             try:
                 events = greenlet.get()
             except:
-                self._run_job_error(job.id, *sys.exc_info()[1:])
+                self._run_job_error(job.id, job_submission_id, job._jobstore_alias, *sys.exc_info()[1:])
             else:
-                self._run_job_success(job.id, events)
+                self._run_job_success(job.id, job_submission_id, job._jobstore_alias, events)
 
-        gevent.spawn(run_job, job, self._logger.name, job_submission_id, run_time).\
+        gevent.spawn(run_job, job, self._logger.name, job_submission_id, job._jobstore_alias, run_time).\
             link(callback)

--- a/apscheduler/executors/pool.py
+++ b/apscheduler/executors/pool.py
@@ -13,12 +13,8 @@ class BasePoolExecutor(BaseExecutor):
 
     def _do_submit_job(self, job, job_submission_id, run_time):
         def callback(f):
-            exc, tb = (f.exception_info() if hasattr(f, 'exception_info') else
-                       (f.exception(), getattr(f.exception(), '__traceback__', None)))
-            if exc:
-                self._run_job_error(job.id, job_submission_id, job._jobstore_alias, exc, tb)
-            else:
-                self._run_job_success(job.id, job_submission_id, job._jobstore_alias, f.result())
+            self._handle_job_event(f.result())
+        
         f = self._pool.submit(run_job, job, self._logger.name, job_submission_id, job._jobstore_alias, run_time)
         f.add_done_callback(callback)
 

--- a/apscheduler/executors/pool.py
+++ b/apscheduler/executors/pool.py
@@ -1,7 +1,7 @@
 from abc import abstractmethod
 import concurrent.futures
 
-from apscheduler.executors.base import BaseExecutor, run_job
+from apscheduler.executors.base import BaseExecutor
 
 
 class BasePoolExecutor(BaseExecutor):
@@ -10,7 +10,7 @@ class BasePoolExecutor(BaseExecutor):
         super(BasePoolExecutor, self).__init__()
         self._pool = pool
 
-    def _do_submit_job(self, job, run_times):
+    def _do_submit_job(self, job, run_times, run_job_func):
         def callback(f):
             exc, tb = (f.exception_info() if hasattr(f, 'exception_info') else
                        (f.exception(), getattr(f.exception(), '__traceback__', None)))
@@ -18,8 +18,8 @@ class BasePoolExecutor(BaseExecutor):
                 self._run_job_error(job.id, exc, tb)
             else:
                 self._run_job_success(job.id, f.result())
-
-        f = self._pool.submit(run_job, job, job._jobstore_alias, run_times, self._logger.name)
+        
+        f = self._pool.submit(run_job_func, job, job._jobstore_alias, run_times, self._logger.name)
         f.add_done_callback(callback)
 
     def shutdown(self, wait=True):

--- a/apscheduler/executors/pool.py
+++ b/apscheduler/executors/pool.py
@@ -1,7 +1,7 @@
 from abc import abstractmethod
 import concurrent.futures
 
-from apscheduler.executors.base import BaseExecutor
+from apscheduler.executors.base import BaseExecutor, run_job
 
 
 class BasePoolExecutor(BaseExecutor):
@@ -10,7 +10,7 @@ class BasePoolExecutor(BaseExecutor):
         super(BasePoolExecutor, self).__init__()
         self._pool = pool
 
-    def _do_submit_job(self, job, run_times, run_job_func):
+    def _do_submit_job(self, job, job_submission_id, run_time):
         def callback(f):
             exc, tb = (f.exception_info() if hasattr(f, 'exception_info') else
                        (f.exception(), getattr(f.exception(), '__traceback__', None)))
@@ -18,8 +18,8 @@ class BasePoolExecutor(BaseExecutor):
                 self._run_job_error(job.id, exc, tb)
             else:
                 self._run_job_success(job.id, f.result())
-        
-        f = self._pool.submit(run_job_func, job, job._jobstore_alias, run_times, self._logger.name)
+
+        f = self._pool.submit(run_job, job, self._logger.name, job_submission_id, run_time)
         f.add_done_callback(callback)
 
     def shutdown(self, wait=True):

--- a/apscheduler/executors/pool.py
+++ b/apscheduler/executors/pool.py
@@ -13,8 +13,12 @@ class BasePoolExecutor(BaseExecutor):
 
     def _do_submit_job(self, job, job_submission_id, run_time):
         def callback(f):
-            self._handle_job_event(f.result())
-        
+            exc, tb = (f.exception_info() if hasattr(f, 'exception_info') else
+                       (f.exception(), getattr(f.exception(), '__traceback__', None)))
+            if exc:
+                self._run_job_error(job.id, job_submission_id, job._jobstore_alias, exc, tb)
+            else:
+                self._run_job_success(job.id, job_submission_id, job._jobstore_alias, f.result())
         f = self._pool.submit(run_job, job, self._logger.name, job_submission_id, job._jobstore_alias, run_time)
         f.add_done_callback(callback)
 

--- a/apscheduler/executors/pool.py
+++ b/apscheduler/executors/pool.py
@@ -1,4 +1,3 @@
-import datetime
 from abc import abstractmethod
 import concurrent.futures
 
@@ -19,7 +18,8 @@ class BasePoolExecutor(BaseExecutor):
                 self._run_job_error(job.id, job_submission_id, job._jobstore_alias, exc, tb)
             else:
                 self._run_job_success(job.id, job_submission_id, job._jobstore_alias, f.result())
-        f = self._pool.submit(run_job, job, self._logger.name, job_submission_id, job._jobstore_alias, run_time)
+        f = self._pool.submit(run_job, job, self._logger.name,
+                              job_submission_id, job._jobstore_alias, run_time)
         f.add_done_callback(callback)
 
     def shutdown(self, wait=True):
@@ -38,6 +38,7 @@ class ThreadPoolExecutor(BasePoolExecutor):
     def __init__(self, max_workers=10):
         pool = concurrent.futures.ThreadPoolExecutor(int(max_workers))
         super(ThreadPoolExecutor, self).__init__(pool)
+
 
 class ProcessPoolExecutor(BasePoolExecutor):
     """

--- a/apscheduler/executors/pool.py
+++ b/apscheduler/executors/pool.py
@@ -15,11 +15,11 @@ class BasePoolExecutor(BaseExecutor):
             exc, tb = (f.exception_info() if hasattr(f, 'exception_info') else
                        (f.exception(), getattr(f.exception(), '__traceback__', None)))
             if exc:
-                self._run_job_error(job.id, exc, tb)
+                self._run_job_error(job.id, job_submission_id, job._jobstore_alias, exc, tb)
             else:
-                self._run_job_success(job.id, f.result())
+                self._run_job_success(job.id, job_submission_id, job._jobstore_alias, f.result())
 
-        f = self._pool.submit(run_job, job, self._logger.name, job_submission_id, run_time)
+        f = self._pool.submit(run_job, job, self._logger.name, job_submission_id, job._jobstore_alias, run_time)
         f.add_done_callback(callback)
 
     def shutdown(self, wait=True):

--- a/apscheduler/executors/pool.py
+++ b/apscheduler/executors/pool.py
@@ -1,3 +1,4 @@
+import datetime
 from abc import abstractmethod
 import concurrent.futures
 
@@ -18,7 +19,6 @@ class BasePoolExecutor(BaseExecutor):
                 self._run_job_error(job.id, job_submission_id, job._jobstore_alias, exc, tb)
             else:
                 self._run_job_success(job.id, job_submission_id, job._jobstore_alias, f.result())
-
         f = self._pool.submit(run_job, job, self._logger.name, job_submission_id, job._jobstore_alias, run_time)
         f.add_done_callback(callback)
 
@@ -38,7 +38,6 @@ class ThreadPoolExecutor(BasePoolExecutor):
     def __init__(self, max_workers=10):
         pool = concurrent.futures.ThreadPoolExecutor(int(max_workers))
         super(ThreadPoolExecutor, self).__init__(pool)
-
 
 class ProcessPoolExecutor(BasePoolExecutor):
     """

--- a/apscheduler/executors/tornado.py
+++ b/apscheduler/executors/tornado.py
@@ -37,12 +37,8 @@ class TornadoExecutor(BaseExecutor):
 
     def _do_submit_job(self, job, job_submission_id, run_time):
         def callback(f):
-            try:
-                events = f.result()
-            except:
-                self._run_job_error(job.id, job_submission_id, job._jobstore_alias, *sys.exc_info()[1:])
-            else:
-                self._run_job_success(job.id, job_submission_id, job._jobstore_alias, events)
+            event = f.result()
+            self._handle_job_event(event)
 
         if iscoroutinefunction(job.func):
             f = run_coroutine_job(job, self._logger.name, job_submission_id, job._jobstore_alias, run_time)

--- a/apscheduler/executors/tornado.py
+++ b/apscheduler/executors/tornado.py
@@ -9,7 +9,6 @@ from apscheduler.executors.base import BaseExecutor
 
 try:
     from inspect import iscoroutinefunction
-    from apscheduler.executors.base_py3 import run_coroutine_job
 except ImportError:
     def iscoroutinefunction(func):
         return False
@@ -44,8 +43,9 @@ class TornadoExecutor(BaseExecutor):
             else:
                 self._run_job_success(job.id, events)
 
+        # run_job_func is either a coroutine function, or a regular function 
         if iscoroutinefunction(job.func):
-            f = run_coroutine_job(job, job._jobstore_alias, run_times, self._logger.name)
+            f = run_job_func(job, job._jobstore_alias, run_times, self._logger.name)
         else:
             f = self.executor.submit(run_job_func, job, job._jobstore_alias, run_times,
                                      self._logger.name)

--- a/apscheduler/executors/tornado.py
+++ b/apscheduler/executors/tornado.py
@@ -40,14 +40,17 @@ class TornadoExecutor(BaseExecutor):
             try:
                 events = f.result()
             except:
-                self._run_job_error(job.id, job_submission_id, job._jobstore_alias, *sys.exc_info()[1:])
+                self._run_job_error(job.id, job_submission_id, job._jobstore_alias,
+                                    *sys.exc_info()[1:])
             else:
                 self._run_job_success(job.id, job_submission_id, job._jobstore_alias, events)
 
         if iscoroutinefunction(job.func):
-            f = run_coroutine_job(job, self._logger.name, job_submission_id, job._jobstore_alias, run_time)
+            f = run_coroutine_job(job, self._logger.name,
+                                  job_submission_id, job._jobstore_alias, run_time)
         else:
-            f = self.executor.submit(run_job, job, self._logger.name, job_submission_id, job._jobstore_alias, run_time)
+            f = self.executor.submit(run_job, job, self._logger.name,
+                                     job_submission_id, job._jobstore_alias, run_time)
 
         f = convert_yielded(f)
         f.add_done_callback(callback)

--- a/apscheduler/executors/tornado.py
+++ b/apscheduler/executors/tornado.py
@@ -5,7 +5,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 from tornado.gen import convert_yielded
 
-from apscheduler.executors.base import BaseExecutor, run_job
+from apscheduler.executors.base import BaseExecutor
 
 try:
     from inspect import iscoroutinefunction
@@ -35,7 +35,7 @@ class TornadoExecutor(BaseExecutor):
         super(TornadoExecutor, self).start(scheduler, alias)
         self._ioloop = scheduler._ioloop
 
-    def _do_submit_job(self, job, run_times):
+    def _do_submit_job(self, job, run_times, run_job_func):
         def callback(f):
             try:
                 events = f.result()
@@ -47,7 +47,7 @@ class TornadoExecutor(BaseExecutor):
         if iscoroutinefunction(job.func):
             f = run_coroutine_job(job, job._jobstore_alias, run_times, self._logger.name)
         else:
-            f = self.executor.submit(run_job, job, job._jobstore_alias, run_times,
+            f = self.executor.submit(run_job_func, job, job._jobstore_alias, run_times,
                                      self._logger.name)
 
         f = convert_yielded(f)

--- a/apscheduler/executors/tornado.py
+++ b/apscheduler/executors/tornado.py
@@ -37,8 +37,12 @@ class TornadoExecutor(BaseExecutor):
 
     def _do_submit_job(self, job, job_submission_id, run_time):
         def callback(f):
-            event = f.result()
-            self._handle_job_event(event)
+            try:
+                events = f.result()
+            except:
+                self._run_job_error(job.id, job_submission_id, job._jobstore_alias, *sys.exc_info()[1:])
+            else:
+                self._run_job_success(job.id, job_submission_id, job._jobstore_alias, events)
 
         if iscoroutinefunction(job.func):
             f = run_coroutine_job(job, self._logger.name, job_submission_id, job._jobstore_alias, run_time)

--- a/apscheduler/executors/tornado.py
+++ b/apscheduler/executors/tornado.py
@@ -40,14 +40,14 @@ class TornadoExecutor(BaseExecutor):
             try:
                 events = f.result()
             except:
-                self._run_job_error(job.id, *sys.exc_info()[1:])
+                self._run_job_error(job.id, job_submission_id, job._jobstore_alias, *sys.exc_info()[1:])
             else:
-                self._run_job_success(job.id, events)
+                self._run_job_success(job.id, job_submission_id, job._jobstore_alias, events)
 
         if iscoroutinefunction(job.func):
-            f = run_coroutine_job(job, self._logger.name, job_submission_id, run_time)
+            f = run_coroutine_job(job, self._logger.name, job_submission_id, job._jobstore_alias, run_time)
         else:
-            f = self.executor.submit(run_job, job, self._logger.name, job_submission_id, run_time)
+            f = self.executor.submit(run_job, job, self._logger.name, job_submission_id, job._jobstore_alias, run_time)
 
         f = convert_yielded(f)
         f.add_done_callback(callback)

--- a/apscheduler/executors/twisted.py
+++ b/apscheduler/executors/twisted.py
@@ -16,10 +16,7 @@ class TwistedExecutor(BaseExecutor):
 
     def _do_submit_job(self, job, job_submission_id, run_time):
         def callback(success, result):
-            if success:
-                self._run_job_success(job.id, job_submission_id, job._jobstore_alias, result)
-            else:
-                self._run_job_error(job.id, job_submission_id, job._jobstore_alias, result.value, result.tb)
+            self._handle_job_event(result)
 
         self._reactor.getThreadPool().callInThreadWithCallback(
             callback, run_job, job, self._logger.name, job_submission_id, job._jobstore_alias, run_time)

--- a/apscheduler/executors/twisted.py
+++ b/apscheduler/executors/twisted.py
@@ -17,9 +17,9 @@ class TwistedExecutor(BaseExecutor):
     def _do_submit_job(self, job, job_submission_id, run_time):
         def callback(success, result):
             if success:
-                self._run_job_success(job.id, result)
+                self._run_job_success(job.id, job_submission_id, job._jobstore_alias, result)
             else:
-                self._run_job_error(job.id, result.value, result.tb)
+                self._run_job_error(job.id, job_submission_id, job._jobstore_alias, result.value, result.tb)
 
         self._reactor.getThreadPool().callInThreadWithCallback(
-            callback, run_job, job, self._logger.name, job_submission_id, run_time)
+            callback, run_job, job, self._logger.name, job_submission_id, job._jobstore_alias, run_time)

--- a/apscheduler/executors/twisted.py
+++ b/apscheduler/executors/twisted.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from apscheduler.executors.base import BaseExecutor, run_job
+from apscheduler.executors.base import BaseExecutor
 
 
 class TwistedExecutor(BaseExecutor):
@@ -14,7 +14,7 @@ class TwistedExecutor(BaseExecutor):
         super(TwistedExecutor, self).start(scheduler, alias)
         self._reactor = scheduler._reactor
 
-    def _do_submit_job(self, job, run_times):
+    def _do_submit_job(self, job, run_times, run_job_func):
         def callback(success, result):
             if success:
                 self._run_job_success(job.id, result)
@@ -22,4 +22,4 @@ class TwistedExecutor(BaseExecutor):
                 self._run_job_error(job.id, result.value, result.tb)
 
         self._reactor.getThreadPool().callInThreadWithCallback(
-            callback, run_job, job, job._jobstore_alias, run_times, self._logger.name)
+            callback, run_job_func, job, job._jobstore_alias, run_times, self._logger.name)

--- a/apscheduler/executors/twisted.py
+++ b/apscheduler/executors/twisted.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from apscheduler.executors.base import BaseExecutor
+from apscheduler.executors.base import BaseExecutor, run_job
 
 
 class TwistedExecutor(BaseExecutor):
@@ -14,7 +14,7 @@ class TwistedExecutor(BaseExecutor):
         super(TwistedExecutor, self).start(scheduler, alias)
         self._reactor = scheduler._reactor
 
-    def _do_submit_job(self, job, run_times, run_job_func):
+    def _do_submit_job(self, job, job_submission_id, run_time):
         def callback(success, result):
             if success:
                 self._run_job_success(job.id, result)
@@ -22,4 +22,4 @@ class TwistedExecutor(BaseExecutor):
                 self._run_job_error(job.id, result.value, result.tb)
 
         self._reactor.getThreadPool().callInThreadWithCallback(
-            callback, run_job_func, job, job._jobstore_alias, run_times, self._logger.name)
+            callback, run_job, job, self._logger.name, job_submission_id, run_time)

--- a/apscheduler/executors/twisted.py
+++ b/apscheduler/executors/twisted.py
@@ -16,7 +16,10 @@ class TwistedExecutor(BaseExecutor):
 
     def _do_submit_job(self, job, job_submission_id, run_time):
         def callback(success, result):
-            self._handle_job_event(result)
+            if success:
+                self._run_job_success(job.id, job_submission_id, job._jobstore_alias, result)
+            else:
+                self._run_job_error(job.id, job_submission_id, job._jobstore_alias, result.value, result.tb)
 
         self._reactor.getThreadPool().callInThreadWithCallback(
             callback, run_job, job, self._logger.name, job_submission_id, job._jobstore_alias, run_time)

--- a/apscheduler/executors/twisted.py
+++ b/apscheduler/executors/twisted.py
@@ -19,7 +19,9 @@ class TwistedExecutor(BaseExecutor):
             if success:
                 self._run_job_success(job.id, job_submission_id, job._jobstore_alias, result)
             else:
-                self._run_job_error(job.id, job_submission_id, job._jobstore_alias, result.value, result.tb)
+                self._run_job_error(job.id, job_submission_id, job._jobstore_alias, result.value,
+                                    result.tb)
 
         self._reactor.getThreadPool().callInThreadWithCallback(
-            callback, run_job, job, self._logger.name, job_submission_id, job._jobstore_alias, run_time)
+            callback, run_job, job, self._logger.name, job_submission_id, job._jobstore_alias,
+            run_time)

--- a/apscheduler/jobstores/base.py
+++ b/apscheduler/jobstores/base.py
@@ -10,6 +10,11 @@ class JobLookupError(KeyError):
     def __init__(self, job_id):
         super(JobLookupError, self).__init__(u'No job by the id of %s was found' % job_id)
 
+class JobInstanceLookupError(KeyError):
+    """Raised when the job store cannot find the *job instance* of job for update or removal."""
+
+    def __init__(self, job_id):
+        super(JobInstanceLookupError, self).__init__(u'No job by the id of %s was found' % job_id)
 
 class ConflictingIdError(KeyError):
     """Raised when the uniqueness of job IDs is being violated."""
@@ -63,6 +68,46 @@ class BaseJobStore(six.with_metaclass(ABCMeta)):
                     del jobs[:i]
                     jobs.extend(paused_jobs)
                 break
+
+    @abstractmethod
+    def add_job_submission(self, job):
+        """ 
+        Adds a job submission to the jobstore, and returns the ID of the inserted record
+    
+        :param Job job: The job which has been submitted to be executed
+        :rtype: int
+        """
+    
+
+    @abstractmethod
+    def update_job_submission(self, job_submission_id, **kwargs):
+        """
+        Updates the job submission designated by ``job_submission_id``, specifically updating the
+        record's attributes specified by keywords in **kwargs
+
+        :param int job_submission_id: The ID of the job_submission in the job_store
+        :param dict kwargs: A dictionary whos keys correspond to attributes (columns) of the 
+        apscheduler_job_submission collection in the jobstore. Common keywords (columns) passed
+        to this function include: ``status``, ``started_at``, and ``completed_at``.
+        
+        """
+    @abstractmethod
+    def get_job_submissions_with_status(self, statuses=[]):
+        """
+        Returns all job submissions in the jobstore which have a status in ``statuses``.
+
+        :param list[str] statuses: List of strings in the set ['submitted','running','failure','success',
+        'orphaned']. Function will fetch job_submissions with any of the provided statuses.
+        :rtype: dict
+        """
+    @abstractmethod
+    def get_job_submission(self, job_submission_id):
+        """
+        Returns the specific job submission with ID ``job_submission_id``.
+
+        :param int job_submission_id: The ID of the ``job_submission` to fetch.
+        :rtype: dict
+        """
 
     @abstractmethod
     def lookup_job(self, job_id):

--- a/apscheduler/jobstores/base.py
+++ b/apscheduler/jobstores/base.py
@@ -61,7 +61,6 @@ class BaseJobStore(six.with_metaclass(ABCMeta)):
         self._logger = logging.getLogger('apscheduler.jobstores.%s' % alias)
         # If jobstore didn't 'stop' gracefully, set all non-finished job_submissions to "orphaned"
     def update_orphans(self):
-        self.update_job_submissions({"state": "running"}, state='orphaned')
         self.update_job_submissions({"state": "submitted"}, state='orphaned')
 
     def shutdown(self):
@@ -69,7 +68,6 @@ class BaseJobStore(six.with_metaclass(ABCMeta)):
         Frees any resources still bound to this job store.
         """
         # Any jobs that haven't finished will be orphaned when we shutdown !
-        self.update_job_submissions({"state": "running"}, state='orphaned')
         self.update_job_submissions({"state": "submitted"}, state='orphaned')
         # TODO: Try and gracefully stop these jobs when we shutdown the jobstore...
 
@@ -83,11 +81,12 @@ class BaseJobStore(six.with_metaclass(ABCMeta)):
                 break
 
     @abstractmethod
-    def add_job_submission(self, job):
+    def add_job_submission(self, job, now):
         """
         Adds a job submission to the jobstore, and returns the ID of the inserted record
 
         :param Job job: The job which has been submitted to be executed
+        :param datetime now: The current datetime.now(timezone) value
         :rtype: int
         """
 

--- a/apscheduler/jobstores/base.py
+++ b/apscheduler/jobstores/base.py
@@ -124,7 +124,7 @@ class BaseJobStore(six.with_metaclass(ABCMeta)):
         :param list[str] states: List of strings in the set ['submitted','running','failure',
         'success','orphaned']. Function will fetch job_submissions with any of the provided
         states.
-        :rtype: dict
+        :rtype: list[dict]
         """
     @abstractmethod
     def get_job_submission(self, job_submission_id):

--- a/apscheduler/jobstores/base.py
+++ b/apscheduler/jobstores/base.py
@@ -59,8 +59,10 @@ class BaseJobStore(six.with_metaclass(ABCMeta)):
         self._scheduler = scheduler
         self._alias = alias
         self._logger = logging.getLogger('apscheduler.jobstores.%s' % alias)
-        # If jobstore didn't 'stop' gracefully, set all non-finished job_submissions to "orphaned"
+
     def update_orphans(self):
+        # If jobstore didn't 'stop' gracefully,
+        # set all non-finished job_submissions to "orphaned"
         self.update_job_submissions({"state": "submitted"}, state='orphaned')
 
     def shutdown(self):

--- a/apscheduler/jobstores/memory.py
+++ b/apscheduler/jobstores/memory.py
@@ -20,13 +20,13 @@ class MemoryJobStore(BaseJobStore):
         self._job_submissions = {}# id -> job_submission
         self._next_id = 1
 
-    def add_job_submission(self, job):
+    def add_job_submission(self, job, now):
         job_submission = {
             'id': self._next_id,
             'state': 'submitted',
             # TODO: Pickle the 'job.func' so we can recover from 2 diff sessions
             'func': job.func if isinstance(job.func, six.string_types) else job.func.__name__,
-            'submitted_at': datetime.datetime.now(),
+            'submitted_at': now,
             'apscheduler_job_id': job.id,
         }
         self._job_submissions[self._next_id] = job_submission
@@ -53,7 +53,7 @@ class MemoryJobStore(BaseJobStore):
                 for k in self._job_submissions \
                 if not states or self._job_submissions[k]['state'] in states]
 
-    def get_job_submission(self, job_submission_id, **kwargs):
+    def get_job_submission(self, job_submission_id):
         return self._job_submissions[job_submission_id]
 
     def lookup_job(self, job_id):

--- a/apscheduler/jobstores/memory.py
+++ b/apscheduler/jobstores/memory.py
@@ -2,7 +2,8 @@ from __future__ import absolute_import
 
 from apscheduler.jobstores.base import BaseJobStore, JobLookupError, ConflictingIdError
 from apscheduler.util import datetime_to_utc_timestamp
-
+import six
+import datetime
 
 class MemoryJobStore(BaseJobStore):
     """
@@ -16,7 +17,7 @@ class MemoryJobStore(BaseJobStore):
         # list of (job, timestamp), sorted by next_run_time and job id (ascending)
         self._jobs = []
         self._jobs_index = {}  # id -> (job, timestamp) lookup table
-        self._job_submissions = # id -> job_submission
+        self._job_submissions = {}# id -> job_submission
         self._next_id = 1
 
     def add_job_submission(self, job):
@@ -25,7 +26,7 @@ class MemoryJobStore(BaseJobStore):
             'state': 'submitted',
             # TODO: Pickle the 'job.func' so we can recover from 2 diff sessions
             'func': job.func if isinstance(job.func, six.string_types) else job.func.__name__,
-            'submitted_at': datetime.now(),
+            'submitted_at': datetime.datetime.now(),
             'apscheduler_job_id': job.id,
         }
         self._job_submissions[self._next_id] = job_submission
@@ -50,7 +51,7 @@ class MemoryJobStore(BaseJobStore):
     def get_job_submissions_with_states(self, states=[]):
         return [self._job_submissions[k] \
                 for k in self._job_submissions \
-                if not states or self._job_submissions[k]['state'] in states]]
+                if not states or self._job_submissions[k]['state'] in states]
 
     def get_job_submission(self, job_submission_id, **kwargs):
         return self._job_submissions[job_submission_id]

--- a/apscheduler/jobstores/memory.py
+++ b/apscheduler/jobstores/memory.py
@@ -54,7 +54,7 @@ class MemoryJobStore(BaseJobStore):
                 if not states or self._job_submissions[k]['state'] in states]
 
     def get_job_submission(self, job_submission_id):
-        return self._job_submissions[job_submission_id]
+        return self._job_submissions.get(job_submission_id)
 
     def lookup_job(self, job_id):
         return self._jobs_index.get(job_id, (None, None))[0]

--- a/apscheduler/jobstores/memory.py
+++ b/apscheduler/jobstores/memory.py
@@ -16,6 +16,44 @@ class MemoryJobStore(BaseJobStore):
         # list of (job, timestamp), sorted by next_run_time and job id (ascending)
         self._jobs = []
         self._jobs_index = {}  # id -> (job, timestamp) lookup table
+        self._job_submissions = # id -> job_submission
+        self._next_id = 1
+
+    def add_job_submission(self, job):
+        job_submission = {
+            'id': self._next_id,
+            'state': 'submitted',
+            # TODO: Pickle the 'job.func' so we can recover from 2 diff sessions
+            'func': job.func if isinstance(job.func, six.string_types) else job.func.__name__,
+            'submitted_at': datetime.now(),
+            'apscheduler_job_id': job.id,
+        }
+        self._job_submissions[self._next_id] = job_submission
+        self._next_id += 1
+        return job_submission['id']
+
+    def update_job_submissions(self, conditions, **kwargs):
+        for _id in self._job_submissions:
+            this_job_submission = self._job_submissions[_id]
+            update_flag = True
+            # If no conditions are given, all job_submissions will be updated
+            for column in conditions:
+                val = conditions[column]
+                if this_job_submission[column] != val:
+                    update_flag = False            
+            if update_flag:
+                this_job_submission.update(kwargs)
+    
+    def update_job_submission(self, job_submission_id, **kwargs):
+        self._job_submissions[job_submission_id].update(kwargs)
+       
+    def get_job_submissions_with_states(self, states=[]):
+        return [self._job_submissions[k] \
+                for k in self._job_submissions \
+                if not states or self._job_submissions[k]['state'] in states]]
+
+    def get_job_submission(self, job_submission_id, **kwargs):
+        return self._job_submissions[job_submission_id]
 
     def lookup_job(self, job_id):
         return self._jobs_index.get(job_id, (None, None))[0]

--- a/apscheduler/jobstores/memory.py
+++ b/apscheduler/jobstores/memory.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from apscheduler.jobstores.base import BaseJobStore, JobLookupError, ConflictingIdError
 from apscheduler.util import datetime_to_utc_timestamp
 import six
-import datetime
+
 
 class MemoryJobStore(BaseJobStore):
     """
@@ -17,7 +17,7 @@ class MemoryJobStore(BaseJobStore):
         # list of (job, timestamp), sorted by next_run_time and job id (ascending)
         self._jobs = []
         self._jobs_index = {}  # id -> (job, timestamp) lookup table
-        self._job_submissions = {}# id -> job_submission
+        self._job_submissions = {}  # id -> job_submission
         self._next_id = 1
 
     def add_job_submission(self, job, now):
@@ -41,16 +41,16 @@ class MemoryJobStore(BaseJobStore):
             for column in conditions:
                 val = conditions[column]
                 if this_job_submission[column] != val:
-                    update_flag = False            
+                    update_flag = False
             if update_flag:
                 this_job_submission.update(kwargs)
-    
+
     def update_job_submission(self, job_submission_id, **kwargs):
         self._job_submissions[job_submission_id].update(kwargs)
-       
+
     def get_job_submissions_with_states(self, states=[]):
-        return [self._job_submissions[k] \
-                for k in self._job_submissions \
+        return [self._job_submissions[k]
+                for k in self._job_submissions
                 if not states or self._job_submissions[k]['state'] in states]
 
     def get_job_submission(self, job_submission_id):

--- a/apscheduler/jobstores/mongodb.py
+++ b/apscheduler/jobstores/mongodb.py
@@ -124,10 +124,13 @@ class MongoDBJobStore(BaseJobStore):
    
     def get_job_submission(self, job_submission_id):
         js = self.job_submission_collection.find_one(job_submission_id)
-        _id = js['_id']
-        js.update({'id': _id})
-        del js['_id']
-        return js
+        if js:
+            _id = js['_id']
+            js.update({'id': _id})
+            del js['_id']
+            return js
+        else:
+            return None
 
     def get_all_jobs(self):
         jobs = self._get_jobs({})

--- a/apscheduler/jobstores/redis.py
+++ b/apscheduler/jobstores/redis.py
@@ -15,6 +15,7 @@ except ImportError:  # pragma: nocover
 
 try:
     from redis import StrictRedis
+    from redis.exceptions import WatchError
 except ImportError:  # pragma: nocover
     raise ImportError('RedisJobStore requires redis installed')
 
@@ -28,13 +29,15 @@ class RedisJobStore(BaseJobStore):
 
     :param int db: the database number to store jobs in
     :param str jobs_key: key to store jobs in
+    :param str job_submissions_key: key to store job_submissions in
     :param str run_times_key: key to store the jobs' run times in
     :param int pickle_protocol: pickle protocol level to use (for serialization), defaults to the
         highest available
     """
 
-    def __init__(self, db=0, jobs_key='apscheduler.jobs', run_times_key='apscheduler.run_times',
-                 pickle_protocol=pickle.HIGHEST_PROTOCOL, **connect_args):
+    def __init__(self, db=0, jobs_key='apscheduler.jobs', job_submissions_key='apscheduler.job_submissions',
+                 run_times_key='apscheduler.run_times', pickle_protocol=pickle.HIGHEST_PROTOCOL,
+                 **connect_args):
         super(RedisJobStore, self).__init__()
 
         if db is None:
@@ -46,6 +49,7 @@ class RedisJobStore(BaseJobStore):
 
         self.pickle_protocol = pickle_protocol
         self.jobs_key = jobs_key
+        self.job_submissions_key = job_submissions_key
         self.run_times_key = run_times_key
         self.redis = StrictRedis(db=int(db), **connect_args)
 
@@ -65,6 +69,72 @@ class RedisJobStore(BaseJobStore):
         next_run_time = self.redis.zrange(self.run_times_key, 0, 0, withscores=True)
         if next_run_time:
             return utc_timestamp_to_datetime(next_run_time[0][1])
+
+    def add_job_submission(self, job, now):
+        with self.redis.pipeline() as pipe:
+            while 1:
+                try:
+                    job_submission = {
+                        'state': 'submitted',
+                        'func': job.func if isinstance(job.func, six.string_types) else job.func.__name__,
+                        'submitted_at': now,
+                        'apscheduler_job_id': job.id
+                    }
+                    # Use length of hash to set ID of job_submissions
+                    pipe.watch(self.job_submissions_key)
+                    current_length = pipe.hlen(self.job_submissions_key)
+                    job_submission_id = int(current_length) + 1
+                    
+                    pipe.multi()
+                    pipe.hset(self.job_submissions_key, str(job_submission_id), 
+                              pickle.dumps(job_submission, self.pickle_protocol))
+                    pipe.execute()
+                    break
+                except WatchError:
+                    # This should never happen due to the jobstore lock !
+                    self._logger.exception("WatchError was raised in Redis jobstore! Multiple threads/workers " +\
+                        "are writing to the jobstore at 1 time! This shouldn't happen due to the jobstore lock...")
+                    raise
+            return job_submission_id
+    
+    def update_job_submissions(self, conditions, **kwargs):
+        # Get all jobs that satisfy conditions
+        job_submissions_dict = self.redis.hgetall(self.job_submissions_key)
+        with self.redis.pipeline() as pipe:
+            for key in job_submissions_dict:
+                job_sub = pickle.loads(job_submissions_dict[key])
+                update_flag = True
+                for column in conditions:
+                    val = conditions[column]
+                    if job_sub[column] != val:
+                        update_flag = False
+                if update_flag:
+                    job_sub.update(kwargs)
+                    pipe.hset(self.job_submissions_key, key,
+                              pickle.dumps(job_sub, self.pickle_protocol))
+            pipe.execute()
+    
+    def update_job_submission(self, job_submission_id, **kwargs):
+        with self.redis.pipeline() as pipe:
+            pipe.hset(self.job_submissions_key, str(job_submission_id),
+                      pickle.dumps(kwargs, self.pickle_protocol))
+            pipe.execute()
+
+    def get_job_submission(self, job_submission_id):
+        pickled_job_submission = self.redis.hget(self.job_submissions_key, str(job_submission_id))
+        job_sub = pickle.loads(pickled_job_submission)
+        job_sub.update({'id': job_submission_id})
+        return job_sub
+       
+    def get_job_submissions_with_states(self, states=[]):
+        job_submissions = []
+        job_submissions_dict = self.redis.hgetall(self.job_submissions_key)
+        for key in job_submissions_dict:
+            job_submission = pickle.loads(job_submissions_dict[key])
+            if len(states) == 0 or job_submission['state'] in states:
+                job_submission.update({"id": int(key)})
+                job_submissions.append(job_submission)
+        return job_submissions
 
     def get_all_jobs(self):
         job_states = self.redis.hgetall(self.jobs_key)
@@ -111,6 +181,11 @@ class RedisJobStore(BaseJobStore):
             pipe.delete(self.jobs_key)
             pipe.delete(self.run_times_key)
             pipe.execute()
+    def remove_all_job_submissions(self):
+        with self.redis.pipeline() as pipe:
+            pipe.delete(self.job_submissions_key)
+            pipe.execute()
+        
 
     def shutdown(self):
         self.redis.connection_pool.disconnect()

--- a/apscheduler/jobstores/redis.py
+++ b/apscheduler/jobstores/redis.py
@@ -122,6 +122,8 @@ class RedisJobStore(BaseJobStore):
 
     def get_job_submission(self, job_submission_id):
         pickled_job_submission = self.redis.hget(self.job_submissions_key, str(job_submission_id))
+        if not pickled_job_submission:
+            return None
         job_sub = pickle.loads(pickled_job_submission)
         job_sub.update({'id': job_submission_id})
         return job_sub

--- a/apscheduler/jobstores/sqlalchemy.py
+++ b/apscheduler/jobstores/sqlalchemy.py
@@ -65,7 +65,7 @@ class SQLAlchemyJobStore(BaseJobStore):
         self.job_submissions_t = Table(
             "apscheduler_job_submissions", metadata,
             Column("id", Integer(), primary_key=True),
-            Column("state", Enum("submitted", "running", "success", "failure", "orphaned")),
+            Column("state", Enum("submitted", "success", "failure", "missed", "orphaned")),
             Column("func", String()),
             Column("submitted_at", DateTime()),
             Column("started_at", DateTime()),
@@ -143,7 +143,7 @@ class SQLAlchemyJobStore(BaseJobStore):
         selectable = self.job_submissions_t.select()\
                 .where(self.submissions_t.c.id == job_submission_id)
         job_submission = self.engine.execute(selectable).scalar()
-        return job_submission
+        return dict(job_submission)
 
     def get_all_jobs(self):
         jobs = self._get_jobs()

--- a/apscheduler/jobstores/sqlalchemy.py
+++ b/apscheduler/jobstores/sqlalchemy.py
@@ -142,7 +142,7 @@ class SQLAlchemyJobStore(BaseJobStore):
         selectable = self.job_submissions_t.select()\
                 .where(self.job_submissions_t.c.id == job_submission_id)
         job_submission = self.engine.execute(selectable).fetchone()
-        return dict(job_submission)
+        return dict(job_submission) if job_submission else None
 
     def get_all_jobs(self):
         jobs = self._get_jobs()

--- a/apscheduler/jobstores/sqlalchemy.py
+++ b/apscheduler/jobstores/sqlalchemy.py
@@ -127,8 +127,7 @@ class SQLAlchemyJobStore(BaseJobStore):
             raise JobSubmissionLookupError(job_submission_id)
 
     def get_job_submissions_with_states(self, states=[]):
-        selectable = select(map(lambda col: getattr(self.job_submissions_t.c, col),
-                            ["id", "state", "func", "submitted_at", "apscheduler_job_id"])).\
+        selectable = self.job_submissions_t.select().\
             order_by(self.job_submissions_t.c.submitted_at)
         if len(states) > 0:
             selectable = selectable.\

--- a/apscheduler/jobstores/sqlalchemy.py
+++ b/apscheduler/jobstores/sqlalchemy.py
@@ -127,7 +127,8 @@ class SQLAlchemyJobStore(BaseJobStore):
             raise JobSubmissionLookupError(job_submission_id)
 
     def get_job_submissions_with_states(self, states=[]):
-        selectable = self.job_submissions_t.select().\
+        selectable = select(map(lambda col: getattr(self.job_submissions_t.c, col),
+                            ["id", "state", "func", "submitted_at", "apscheduler_job_id"])).\
             order_by(self.job_submissions_t.c.submitted_at)
         if len(states) > 0:
             selectable = selectable.\

--- a/apscheduler/jobstores/sqlalchemy.py
+++ b/apscheduler/jobstores/sqlalchemy.py
@@ -103,6 +103,13 @@ class SQLAlchemyJobStore(BaseJobStore):
         job_submission_id = r.inserted_primary_key[0]
         return job_submission_id
     
+    def update_job_submissions(self, conditions, **kwargs):
+        update = self.job_submissions_t\
+                .update(kwargs)\
+                .where(and_(*tuple([key == value for key, value in kwargs.iteritems()])))
+        result = self.engine.execute(update)
+        self._logger.info("Updated '{0}' rows WHERE '{1}'...set values to: '{2}'"
+                .format(str(result.rowcount), str(conditions), str(kwargs)))
     def update_job_submission(self, job_submission_id, **kwargs):
         update = self.job_submissions_t\
                 .update(kwargs)\

--- a/apscheduler/jobstores/sqlalchemy.py
+++ b/apscheduler/jobstores/sqlalchemy.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from datetime import datetime
 import six
 
 from apscheduler.jobstores.base import (
@@ -110,8 +109,8 @@ class SQLAlchemyJobStore(BaseJobStore):
                 .update()\
                 .values(kwargs)\
                 .where(and_(
-                    *tuple([getattr(self.job_submissions_t.c, key) == conditions[key] 
-                        for key in conditions])))
+                    *tuple([getattr(self.job_submissions_t.c, key) == conditions[key]
+                            for key in conditions])))
         self._logger.info(update)
         result = self.engine.execute(update)
         self._logger.info("Updated '{0}' rows WHERE '{1}'...set values to: '{2}'"

--- a/apscheduler/jobstores/zookeeper.py
+++ b/apscheduler/jobstores/zookeeper.py
@@ -161,10 +161,13 @@ class ZooKeeperJobStore(BaseJobStore):
     def get_job_submission(self, job_submission_id):
         self._ensure_paths()
         node_path = os.path.join(self.job_submission_path, job_submission_id)
-        content, _ = self.client.get(node_path)
-        doc = pickle.loads(content)
-        doc.update({"id": job_submission_id})
-        return doc
+        try:
+            content, _ = self.client.get(node_path)
+            doc = pickle.loads(content)
+            doc.update({"id": job_submission_id})
+            return doc
+        except:
+            return None
 
     def get_all_jobs(self):
         jobs = [job_def['job'] for job_def in self._get_jobs()]

--- a/apscheduler/jobstores/zookeeper.py
+++ b/apscheduler/jobstores/zookeeper.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import
+import six
 
 import os
 from datetime import datetime
+import time
 
 from pytz import utc
 from kazoo.exceptions import NoNodeError, NodeExistsError
@@ -36,7 +38,7 @@ class ZooKeeperJobStore(BaseJobStore):
         highest available
     """
 
-    def __init__(self, path='/apscheduler', client=None, close_connection_on_exit=False,
+    def __init__(self, path='/apscheduler', job_submission_path='/apscheduler_job_submissions', client=None, close_connection_on_exit=False,
                  pickle_protocol=pickle.HIGHEST_PROTOCOL, **connect_args):
         super(ZooKeeperJobStore, self).__init__()
         self.pickle_protocol = pickle_protocol
@@ -45,7 +47,11 @@ class ZooKeeperJobStore(BaseJobStore):
         if not path:
             raise ValueError('The "path" parameter must not be empty')
 
+        if not job_submission_path:
+            raise ValueError('The "job_submission_path" parameter must not be empty')
+        
         self.path = path
+        self.job_submission_path = job_submission_path
 
         if client:
             self.client = maybe_ref(client)
@@ -56,6 +62,7 @@ class ZooKeeperJobStore(BaseJobStore):
     def _ensure_paths(self):
         if not self._ensured_path:
             self.client.ensure_path(self.path)
+            self.client.ensure_path(self.job_submission_path)
         self._ensured_path = True
 
     def start(self, scheduler, alias):
@@ -84,6 +91,80 @@ class ZooKeeperJobStore(BaseJobStore):
         next_runs = [job_def['next_run_time'] for job_def in self._get_jobs()
                      if job_def['next_run_time'] is not None]
         return utc_timestamp_to_datetime(min(next_runs)) if len(next_runs) > 0 else None
+
+    def add_job_submission(self, job, now):
+        self._ensure_paths()
+        utc_now = now.astimezone(utc)
+        job_submission_id = job.id + "_" + \
+            str((utc_now - utc.localize(datetime(1970, 1, 1))).total_seconds() * 1000 )
+        node_path = os.path.join(self.job_submission_path, job_submission_id)
+        self._logger.info(node_path)
+        value = {
+            'state': 'submitted',
+            # TODO: Pickle the 'job.func' so we can recover from 2 diff sessions
+            'func': job.func if isinstance(job.func, six.string_types) else job.func.__name__,
+            'submitted_at': now,
+            'apscheduler_job_id': job.id,
+        }
+        data = pickle.dumps(value, self.pickle_protocol)
+        try:
+            self.client.create(node_path, value=data)
+        except NodeExistsError:
+            raise ConflictingIdError(job_submission_id)
+        return job_submission_id
+
+    def update_job_submission(self, job_submission_id, **kwargs):
+        self._ensure_paths()
+        node_path = os.path.join(self.job_submission_path, job_submission_id)
+        try:
+            # Get current job_submission data
+            content, _ = self.client.get(node_path)
+            doc = pickle.loads(content)
+            # Update the job_submission data
+            doc.update(kwargs)    
+            data = pickle.dumps(doc, self.pickle_protocol)
+            self.client.set(node_path, value=data)
+        except NoNodeError:
+            raise JobSubmissionLookupError(job_submission_id)
+
+    def update_job_submissions(self, conditions, **kwargs):
+        self._ensure_paths()
+        job_submissions = self.get_job_submissions_with_states()
+        for js in job_submissions:
+            node_path = os.path.join(self.job_submission_path, js['id'])
+            update_flag = True
+            for column in conditions:
+                val = conditions[column]
+                if js[column] != val:
+                    update_flag = False
+            if update_flag:
+                js.update(kwargs)
+                data = pickle.dumps(js, self.pickle_protocol)
+                self.client.set(node_path, value=data)
+    
+    def get_job_submissions_with_states(self, states=[]):
+        self._ensure_paths()
+        job_submissions = []
+        all_ids = self.client.get_children(self.job_submission_path)
+        for node_name in all_ids:
+            try:
+                node_path = os.path.join(self.job_submission_path, node_name)
+                content, _ = self.client.get(node_path)
+                doc = pickle.loads(content)
+                if len(states) == 0 or doc['state'] in states:
+                    doc.update({"id": node_name})
+                    job_submissions.append(doc)
+            except:
+                self._logger.exception('Unable to restore job submission "%s"' % node_name)
+        return job_submissions
+
+    def get_job_submission(self, job_submission_id):
+        self._ensure_paths()
+        node_path = os.path.join(self.job_submission_path, job_submission_id)
+        content, _ = self.client.get(node_path)
+        doc = pickle.loads(content)
+        doc.update({"id": job_submission_id})
+        return doc
 
     def get_all_jobs(self):
         jobs = [job_def['job'] for job_def in self._get_jobs()]
@@ -127,6 +208,13 @@ class ZooKeeperJobStore(BaseJobStore):
     def remove_all_jobs(self):
         try:
             self.client.delete(self.path, recursive=True)
+        except NoNodeError:
+            pass
+        self._ensured_path = False
+    
+    def remove_all_job_submissions(self):
+        try:
+            self.client.delete(self.job_submission_path, recursive=True)
         except NoNodeError:
             pass
         self._ensured_path = False

--- a/apscheduler/schedulers/base.py
+++ b/apscheduler/schedulers/base.py
@@ -145,7 +145,7 @@ class BaseScheduler(six.with_metaclass(ABCMeta)):
             # Start all the job stores
             for alias, store in six.iteritems(self._jobstores):
                 store.start(self, alias)
-
+                store.update_orphans()
             # Schedule all pending jobs
             for job, jobstore_alias, replace_existing in self._pending_jobs:
                 self._real_add_job(job, jobstore_alias, replace_existing)

--- a/apscheduler/schedulers/base.py
+++ b/apscheduler/schedulers/base.py
@@ -432,6 +432,46 @@ class BaseScheduler(six.with_metaclass(ABCMeta)):
 
         return job
 
+    def get_job_submissions(self, jobstore):
+        """
+        Gets all job submissions in a jobstore
+
+        :param str jobstore: The name of the jobstore where the job_submission is stored
+        :rtype: dict
+        
+        """
+        
+        # This gets ALL job_submissions (b/c we don't provide the 'states' parameter
+        return self._lookup_jobstore(jobstore).get_job_submissions_with_states()
+    
+    def get_job_submission(self, jobstore, job_submission_id):
+        """
+        Gets specific job_submission from jobstore
+
+        :param str jobstore: The name of the jobstore where the job_submission is stored
+        :param str|int job_submission_id: The unique identifier of the job_submission
+        :rtype: dict
+        
+        """
+        
+        # This gets ALL job_submissions (b/c we don't provide the 'states' parameter
+        return self._lookup_jobstore(jobstore).get_job_submission(job_submission_id)
+    
+    def get_job_submissions_for_job(self, jobstore, job_id):
+        """
+        Gets job_submissions for a specific job
+
+        :param str jobstore: The name of the jobstore where the job_submission is stored
+        :param str|int job_id: The unique identifier of the job
+        :rtype: list(dict)
+        
+        """
+        
+        #TODO: Implement this function at the jobstore level to optimze this query, rather
+        # than fetching ALL job_submissions, and then filtering.
+        return filter(lambda js: js['apscheduler_job_id'] == job_id,
+                      self._lookup_jobstore(jobstore).get_job_submissions_with_states())
+
     def scheduled_job(self, trigger, args=None, kwargs=None, id=None, name=None,
                       misfire_grace_time=undefined, coalesce=undefined, max_instances=undefined,
                       next_run_time=undefined, jobstore='default', executor='default',
@@ -527,7 +567,7 @@ class BaseScheduler(six.with_metaclass(ABCMeta)):
                 return self.modify_job(job_id, jobstore, next_run_time=next_run_time)
             else:
                 self.remove_job(job.id, jobstore)
-
+ 
     def get_jobs(self, jobstore=None, pending=None):
         """
         Returns a list of pending jobs (if the scheduler hasn't been started yet) and scheduled

--- a/examples/executors/processpool.py
+++ b/examples/executors/processpool.py
@@ -4,8 +4,15 @@ Demonstrates how to schedule a job to be run in a process pool on 3 second inter
 
 from datetime import datetime
 import os
+from logging import StreamHandler
+
+import logging
 
 from apscheduler.schedulers.blocking import BlockingScheduler
+logging.basicConfig(level=logging.DEBUG,
+                    format='%(asctime)s %(levelname)-8s %(message)s',
+                    datefmt='%Y-%m-%d %H:%M:%S',
+                    handler=StreamHandler)
 
 
 def tick():
@@ -21,4 +28,5 @@ if __name__ == '__main__':
     try:
         scheduler.start()
     except (KeyboardInterrupt, SystemExit):
-        pass
+        raise
+        

--- a/examples/jobstores/sqlalchemy_.py
+++ b/examples/jobstores/sqlalchemy_.py
@@ -10,14 +10,29 @@ from datetime import datetime, timedelta
 import sys
 import os
 
+from logging import StreamHandler
+import logging
+
+from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.schedulers.blocking import BlockingScheduler
 
+l = logging.getLogger("apscheduler.scheduler")
+l.addHandler(StreamHandler())
+l.setLevel(logging.DEBUG)
+
+l2= logging.getLogger("concurrent.futures")
+l2.addHandler(StreamHandler())
+l2.setLevel(logging.DEBUG)
+l3 = logging.getLogger("apscheduler.executors.default")
+l3.addHandler(StreamHandler())
+l3.setLevel(logging.DEBUG)
 
 def alarm(time):
     print('Alarm! This alarm was scheduled at %s.' % time)
 
 
 if __name__ == '__main__':
+    print "FUCK"
     scheduler = BlockingScheduler()
     url = sys.argv[1] if len(sys.argv) > 1 else 'sqlite:///example.sqlite'
     scheduler.add_jobstore('sqlalchemy', url=url)
@@ -29,4 +44,4 @@ if __name__ == '__main__':
     try:
         scheduler.start()
     except (KeyboardInterrupt, SystemExit):
-        pass
+        print "TURD FERGUSON"

--- a/examples/misc/reference.py
+++ b/examples/misc/reference.py
@@ -3,9 +3,13 @@ Basic example showing how to schedule a callable using a textual reference.
 """
 
 import os
+import logging
 
 from apscheduler.schedulers.blocking import BlockingScheduler
-
+logging.basicConfig(level=logging.DEBUG,
+                    format='%(asctime)s %(levelname)-8s %(message)s',
+                    datefmt='%Y-%m-%d %H:%M:%S',
+                    filename="here.txt", filemode='a')
 
 if __name__ == '__main__':
     scheduler = BlockingScheduler()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,6 +75,7 @@ def freeze_time(monkeypatch, timezone):
     monkeypatch.setattr('apscheduler.executors.base.datetime', fake_datetime)
     monkeypatch.setattr('apscheduler.triggers.interval.datetime', fake_datetime)
     monkeypatch.setattr('apscheduler.triggers.date.datetime', fake_datetime)
+    
     return freezer
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,7 +75,7 @@ def freeze_time(monkeypatch, timezone):
     monkeypatch.setattr('apscheduler.executors.base.datetime', fake_datetime)
     monkeypatch.setattr('apscheduler.triggers.interval.datetime', fake_datetime)
     monkeypatch.setattr('apscheduler.triggers.date.datetime', fake_datetime)
-    
+
     return freezer
 
 

--- a/tests/test_executors.py
+++ b/tests/test_executors.py
@@ -19,6 +19,7 @@ except ImportError:
 def mock_scheduler(timezone):
     scheduler_ = Mock(BaseScheduler, timezone=timezone)
     scheduler_._create_lock = MagicMock()
+    scheduler_._jobstores_lock = MagicMock()
     return scheduler_
 
 
@@ -75,6 +76,7 @@ def test_submit_job(mock_scheduler, executor, create_job, freeze_time, timezone,
     successfully executed.
 
     """
+
     mock_scheduler._dispatch_event = MagicMock()
     job = create_job(func=func, id='foo')
     job._jobstore_alias = 'test_jobstore'

--- a/tests/test_executors.py
+++ b/tests/test_executors.py
@@ -19,7 +19,7 @@ except ImportError:
 def mock_scheduler(timezone):
     scheduler_ = Mock(BaseScheduler, timezone=timezone)
     scheduler_._create_lock = MagicMock()
-    scheduler_._jobstores_lock = MagicMock()
+    scheduler_._add_job_submission = MagicMock(return_value=1)
     return scheduler_
 
 
@@ -55,10 +55,10 @@ def test_max_instances(mock_scheduler, executor, create_job, freeze_time):
     events = []
     mock_scheduler._dispatch_event = lambda event: events.append(event)
     job = create_job(func=wait_event, max_instances=2, next_run_time=None)
-    executor.submit_job(job, [freeze_time.current])
-    executor.submit_job(job, [freeze_time.current])
+    executor.submit_job(job, freeze_time.current)
+    executor.submit_job(job, freeze_time.current)
 
-    pytest.raises(MaxInstancesReachedError, executor.submit_job, job, [freeze_time.current])
+    pytest.raises(MaxInstancesReachedError, executor.submit_job, job, freeze_time.current)
     executor.shutdown()
     assert len(events) == 2
     assert events[0].retval == 'test'
@@ -67,9 +67,8 @@ def test_max_instances(mock_scheduler, executor, create_job, freeze_time):
 
 @pytest.mark.parametrize('event_code,func', [
     (EVENT_JOB_EXECUTED, success),
-    (EVENT_JOB_MISSED, failure),
     (EVENT_JOB_ERROR, failure)
-], ids=['executed', 'missed', 'error'])
+], ids=['executed', 'error'])
 def test_submit_job(mock_scheduler, executor, create_job, freeze_time, timezone, event_code, func):
     """
     Tests that an EVENT_JOB_EXECUTED event is delivered to the scheduler if the job was
@@ -82,7 +81,7 @@ def test_submit_job(mock_scheduler, executor, create_job, freeze_time, timezone,
     job._jobstore_alias = 'test_jobstore'
     run_time = (timezone.localize(datetime(1970, 1, 1)) if event_code == EVENT_JOB_MISSED else
                 freeze_time.current)
-    executor.submit_job(job, [run_time])
+    executor.submit_job(job, run_time)
     executor.shutdown()
 
     assert mock_scheduler._dispatch_event.call_count == 1
@@ -104,13 +103,13 @@ class FauxJob(object):
     _jobstore_alias = 'foo'
 
 
-def dummy_run_job(job, jobstore_alias, run_times, logger_name):
+def dummy_run_job(job, logger_name, job_submission_id, jobstore_alias, run_time):
     raise Exception('dummy')
 
 
 def test_run_job_error(monkeypatch, executor):
     """Tests that _run_job_error is properly called if an exception is raised in run_job()"""
-    def run_job_error(job_id, exc, traceback):
+    def run_job_error(job_id, job_submission_id, jobstore_alias, exc, traceback):
         assert job_id == 'abc'
         exc_traceback[:] = [exc, traceback]
         event.set()

--- a/tests/test_executors_py35.py
+++ b/tests/test_executors_py35.py
@@ -56,9 +56,11 @@ async def test_run_coroutine_job(asyncio_scheduler, asyncio_executor, exception)
 
     future = Future()
     job = asyncio_scheduler.add_job(waiter, 'interval', seconds=1, args=[sleep, exception])
-    asyncio_executor._run_job_success = lambda job_id, events: future.set_result(events)
-    asyncio_executor._run_job_error = lambda job_id, exc, tb: future.set_exception(exc)
-    asyncio_executor.submit_job(job, [datetime.now(utc)])
+    asyncio_executor._run_job_success = \
+        lambda job_id, job_submission_id, jobstore_alias, events: future.set_result(events)
+    asyncio_executor._run_job_error = \
+        lambda job_id, job_submission_id, jobstore_alias, exc, tb: future.set_exception(exc)
+    asyncio_executor.submit_job(job, datetime.now(utc))
     events = await future
     assert len(events) == 1
     if exception:
@@ -75,8 +77,10 @@ async def test_run_coroutine_job_tornado(tornado_scheduler, tornado_executor, ex
 
     future = Future()
     job = tornado_scheduler.add_job(waiter, 'interval', seconds=1, args=[sleep, exception])
-    tornado_executor._run_job_success = lambda job_id, events: future.set_result(events)
-    tornado_executor._run_job_error = lambda job_id, exc, tb: future.set_exception(exc)
+    tornado_executor._run_job_success = \
+        lambda job_id, job_submission_id, jobstore_alias, events: future.set_result(events)
+    tornado_executor._run_job_error = \
+        lambda job_id, job_submission_id, jobstore_alias, exc, tb: future.set_exception(exc)
     tornado_executor.submit_job(job, [datetime.now(utc)])
     events = await future
     assert len(events) == 1

--- a/tests/test_jobstores.py
+++ b/tests/test_jobstores.py
@@ -1,4 +1,5 @@
-from datetime import datetime
+from datetime import datetime, timedelta
+import time
 
 import pytest
 
@@ -101,6 +102,11 @@ def create_add_job(timezone, create_job):
         return job
 
     return create
+
+def test_submit_job_and_get_submission(jobstore, create_add_job):
+    initial_job = create_add_job(jobstore, dummy_job, datetime.now())
+    job_subs = jobstore.get_job_submissions_with_states(['submitted', 'running', 'orphaned','success','failure'])
+    assert(job_subs[0].apscheduler_job_id == initial_job.id)
 
 
 def test_lookup_job(jobstore, create_add_job):

--- a/tests/test_jobstores.py
+++ b/tests/test_jobstores.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 import time
 
 import pytest
+from pytz import utc
 
 from apscheduler.jobstores.memory import MemoryJobStore
 from apscheduler.jobstores.base import JobLookupError, ConflictingIdError
@@ -62,6 +63,7 @@ def redisjobstore():
     store.start(None, 'redis')
     yield store
     store.remove_all_jobs()
+    store.remove_all_job_submissions()
     store.shutdown()
 
 
@@ -72,6 +74,7 @@ def zookeeperjobstore():
     store.start(None, 'zookeeper')
     yield store
     store.remove_all_jobs()
+    store.remove_all_job_submissions()
     store.shutdown()
 
 
@@ -103,11 +106,71 @@ def create_add_job(timezone, create_job):
 
     return create
 
-def test_submit_job_and_get_submission(jobstore, create_add_job):
-    initial_job = create_add_job(jobstore, dummy_job, datetime.now())
-    job_subs = jobstore.get_job_submissions_with_states(['submitted', 'running', 'orphaned','success','failure'])
-    assert(job_subs[0].apscheduler_job_id == initial_job.id)
+@pytest.fixture
+def create_add_job_submission(timezone, create_job):
+    def create(jobstore, func=dummy_job, run_date=datetime(2999, 1, 1), id=None, paused=False,
+                **kwargs):
+        run_date = timezone.localize(run_date)
+        job = create_job(func=func, trigger='date', trigger_args={'run_date': run_date}, id=id,
+                         **kwargs)
+        job.next_run_time = None if paused else job.trigger.get_next_fire_time(None, run_date)
+        job_submission_id = jobstore.add_job_submission(job, datetime.now(timezone))
+        return job_submission_id 
+    return create
 
+     
+def test_get_job_submission(jobstore, create_add_job_submission):
+    job_submission_id = create_add_job_submission(jobstore)
+    assert job_submission_id is not None
+    job_submission = jobstore.get_job_submission(job_submission_id)
+    assert type(job_submission) is dict
+    assert 'id' in job_submission.keys()
+    assert job_submission_id == job_submission['id']
+
+def test_get_all_job_submissions(jobstore, create_add_job_submission):
+    job_submission_id_1 = create_add_job_submission(jobstore, dummy_job, datetime(2016, 6, 6))
+    job_submission_id_2 = create_add_job_submission(jobstore, dummy_job, datetime(2016, 7, 7))
+    job_submission_id_3 = create_add_job_submission(jobstore)
+    assert job_submission_id_1 is not None
+    assert job_submission_id_2 is not None
+    assert job_submission_id_3 is not None
+    job_submissions = jobstore.get_job_submissions_with_states(states=[])
+    assert(type(job_submissions) is list)
+    assert(len(job_submissions) == 3)
+
+def test_get_job_submissions_by_state(jobstore, create_add_job_submission):
+    job_submission_id_1 = create_add_job_submission(jobstore, dummy_job, datetime(2016, 6, 6))
+    job_submission_id_2 = create_add_job_submission(jobstore, dummy_job, datetime(2016, 7, 7))
+    job_submission_id_3 = create_add_job_submission(jobstore)
+    assert job_submission_id_1 is not None
+    assert job_submission_id_2 is not None
+    assert job_submission_id_3 is not None
+    job_submissions = jobstore.get_job_submissions_with_states(states=['submitted'])
+    assert(type(job_submissions) is list)
+    assert(len(job_submissions) == 3)
+    empty_job_submissions = jobstore.get_job_submissions_with_states(states=['completed'])
+    assert(len(empty_job_submissions) == 0)
+
+def test_update_job_submission(jobstore, create_add_job_submission):
+    job_submission_id = create_add_job_submission(jobstore, dummy_job, datetime(2016, 6, 6))
+    now = utc.localize(datetime.now())
+    jobstore.update_job_submission(job_submission_id,
+                                   state='success',
+                                   completed_at=now)
+    job_submission = jobstore.get_job_submission(job_submission_id)
+    assert(job_submission['state'] == 'success')
+    updated_time = job_submission['completed_at']
+    assert(updated_time.minute == now.minute and updated_time.second == now.second)
+    assert(job_submission['id'] == job_submission_id)
+        
+def test_update_job_submissions(jobstore, create_add_job_submission):
+    job_submission_ids = [create_add_job_submission(jobstore, dummy_job, datetime(2016, 6, 6)) for i in range(0,3) ]
+
+    jobstore.update_job_submissions({"state": "submitted"}, state="orphaned")
+
+    job_submissions = map(lambda _id: jobstore.get_job_submission(_id), job_submission_ids)
+    for js in job_submissions:
+        assert(js['state'] == 'orphaned')
 
 def test_lookup_job(jobstore, create_add_job):
     initial_job = create_add_job(jobstore)

--- a/tests/test_schedulers.py
+++ b/tests/test_schedulers.py
@@ -72,6 +72,21 @@ class DummyJobStore(BaseJobStore):
         self.start = MagicMock()
         self.shutdown = MagicMock()
 
+    def add_job_submission(self, job):
+        pass
+
+    def get_job_submission(self, job_submission_id):
+        pass
+
+    def get_job_submissions_with_states(self, statuses):
+        pass
+
+    def update_job_submission(self, job_submission_id, **kwargs):
+        pass
+
+    def update_job_submissions(self, conditions, **kwargs):
+        pass
+
     def get_due_jobs(self, now):
         pass
 

--- a/tests/test_schedulers.py
+++ b/tests/test_schedulers.py
@@ -767,7 +767,7 @@ Jobstore other:
         scheduler._process_jobs()
 
         assert len(events) == 1
-        assert events[0].scheduled_run_times == [freeze_time.get(scheduler.timezone)]
+        assert events[0].scheduled_run_times == freeze_time.get(scheduler.timezone)
 
     @pytest.mark.parametrize('scheduler_events', [EVENT_JOB_MAX_INSTANCES],
                              indirect=['scheduler_events'])
@@ -783,15 +783,17 @@ Jobstore other:
         scheduler._process_jobs()
 
         assert len(scheduler_events) == 1
-        assert scheduler_events[0].scheduled_run_times == [freeze_time.get(scheduler.timezone)]
+        assert scheduler_events[0].scheduled_run_times == freeze_time.get(scheduler.timezone)
 
 
 class TestProcessJobs(object):
     @pytest.fixture
-    def job(self):
+    def job(self, freeze_time):
         job = MagicMock(Job, id=999, executor='default')
         job.trigger = MagicMock(get_next_fire_time=MagicMock(return_value=None))
         job. __str__ = lambda x: 'job 999'
+        job._get_run_times = MagicMock(return_value=[])
+        job.misfire_grace_time = None 
         return job
 
     @pytest.fixture
@@ -828,21 +830,23 @@ class TestProcessJobs(object):
             'Executor lookup ("default") failed for job "job 999" -- removing it from the job ' \
             'store'
 
-    def test_max_instances_reached(self, scheduler, job, jobstore, executor, caplog):
+    def test_max_instances_reached(self, scheduler, job, jobstore, executor, caplog, freeze_time):
         """Tests that a warning is logged when the maximum instances of a job is reached."""
         caplog.set_level(logging.WARNING)
         executor.submit_job = MagicMock(side_effect=MaxInstancesReachedError(job))
-
+        
+        job._get_run_times = MagicMock(return_value=[freeze_time.current - timedelta(seconds=30)])
         assert scheduler._process_jobs() is None
-        assert len(caplog.records) == 1
-        assert caplog.records[0].message == \
+        assert len(caplog.records) == 2
+        assert caplog.records[1].message == \
             'Execution of job "job 999" skipped: maximum number of running instances reached (1)'
 
-    def test_executor_error(self, scheduler, jobstore, executor, caplog):
+    def test_executor_error(self, scheduler, job, jobstore, executor, caplog, freeze_time):
         """Tests that if any exception is raised in executor.submit(), it is logged."""
         caplog.set_level(logging.ERROR)
         executor.submit_job = MagicMock(side_effect=Exception('test message'))
-
+        job._get_run_times = MagicMock(return_value=[freeze_time.current - timedelta(seconds=30)])
+        
         assert scheduler._process_jobs() is None
         assert len(caplog.records) == 1
         assert 'test message' in caplog.records[0].exc_text
@@ -858,6 +862,24 @@ class TestProcessJobs(object):
         assert scheduler._process_jobs() is None
         job._modify.assert_called_once_with(next_run_time=next_run_time)
         jobstore.update_job.assert_called_once_with(job)
+
+    def test_report_missed_jobs(self, caplog, scheduler, executor, job, jobstore, freeze_time):
+        """
+        Tests that jobs that were missed are reported via events, and have their
+        job_submissions added to the database
+        """
+        caplog.set_level(logging.WARNING)
+        executor.submit_job = MagicMock(return_value=None)
+        job._get_run_times = MagicMock(return_value=[
+            freeze_time.current - timedelta(seconds=15),
+            ])
+        
+        assert scheduler._process_jobs() is None
+        assert len(caplog.records) == 1
+        assert 'Run time of job "job 999" was missed by' in caplog.records[0].message
+
+    def test_update_job_submission():
+        pass
 
     def test_wait_time(self, scheduler, freeze_time):
         """

--- a/tests/test_schedulers.py
+++ b/tests/test_schedulers.py
@@ -793,7 +793,7 @@ class TestProcessJobs(object):
         job.trigger = MagicMock(get_next_fire_time=MagicMock(return_value=None))
         job. __str__ = lambda x: 'job 999'
         job._get_run_times = MagicMock(return_value=[])
-        job.misfire_grace_time = None 
+        job.misfire_grace_time = None
         return job
 
     @pytest.fixture
@@ -834,7 +834,7 @@ class TestProcessJobs(object):
         """Tests that a warning is logged when the maximum instances of a job is reached."""
         caplog.set_level(logging.WARNING)
         executor.submit_job = MagicMock(side_effect=MaxInstancesReachedError(job))
-        
+
         job._get_run_times = MagicMock(return_value=[freeze_time.current - timedelta(seconds=30)])
         assert scheduler._process_jobs() is None
         assert len(caplog.records) == 2
@@ -846,7 +846,7 @@ class TestProcessJobs(object):
         caplog.set_level(logging.ERROR)
         executor.submit_job = MagicMock(side_effect=Exception('test message'))
         job._get_run_times = MagicMock(return_value=[freeze_time.current - timedelta(seconds=30)])
-        
+
         assert scheduler._process_jobs() is None
         assert len(caplog.records) == 1
         assert 'test message' in caplog.records[0].exc_text
@@ -873,13 +873,10 @@ class TestProcessJobs(object):
         job._get_run_times = MagicMock(return_value=[
             freeze_time.current - timedelta(seconds=15),
             ])
-        
+
         assert scheduler._process_jobs() is None
         assert len(caplog.records) == 1
         assert 'Run time of job "job 999" was missed by' in caplog.records[0].message
-
-    def test_update_job_submission():
-        pass
 
     def test_wait_time(self, scheduler, freeze_time):
         """


### PR DESCRIPTION
# Job Submissions

This is a large change that essentially inserts a `job_submission` into the jobstore each time a job is run by the executor, and tracks this `job_submission` throughout its lifecycle. A `job_submission` object is defined as follows:

> **int|str id**: _Unique identifier, int|str depending on the jobstore/strategy for UID generation_
> **int|str apscheduler_job_id**: _Identifier which references the `job` which spawned this `job_submission`_
> **str func:** _The **name** of the function which the job is scheduled to run. This is preserved on the job_submission so that if the `job` is removed from the jobstore, we can still run analytics on job_submissions based on the python function that this submission ran._
> **datetime submitted_at**: _The date & time the job_submission was submitted by the executor._
> **datetime completed_at**: _The date & time that the executor reported the job as completing._
> **str state**:  _The state that the job_submission is currently in._
> - _submitted_ - The job has been submitted by the scheduler, to the executor to be run
> - _success_ - The job has completed successfully
> - _failure_ - The job has completed unsuccessfully
> - _missed_ - The job was missed at the given `submitted_at` time.
> - _orphaned_ - The job was previously in a _submitted_ state, but the scheduler or jobstore ungracefully stopped without updating the job, leaving it running or stopped in an untracked state.
> 

Other changes include:

1. Executors are no longer responsible for running a job several times, depending on the `run_times` argument passed to `submit_job`. This responsibility now falls on the `scheduler`. If job.coalesce = False, and the missed run times fall within the `job.grace_period`, the scheduler will call `submit_job()` for each run_time when it is looking through jobs in `process_jobs()`.
2. The following public methods have been added to each jobstore to support job_submissions:

   - `add_job_submission(self, job, now)`
   - `update_job_submission(self, job_submission_id, **kwargs)`
   - `update_job_submissions(self, conditions, **kwargs)`
   - `get_job_submissions_with_states(self, states=[])`
   - `get_job_submission(self, job_submission_id)`
_* Note that no method for DELETE is implemented for CRUD surrounding job_submissions, as a job_submission should never be deleted.

3. The Scheduler's Public API has gained 3 methods, providing READ access to job_submissions:
   - `get_job_submissions(self, jobstore)`
   - `get_job_submission(self, jobstore, job_submission_id)`
   - `get_job_submissions_for_job(self, jobstore, job_id)`
4. JobExecutionEvents now take a `job_submission_id` and a `scheduled_run_time` has parameters to support job_submission listeners via Public Events API.

All tests are passing via tox (on all Python distributions), all above functions have added unit tests that are passing, and flake8 tests pass concerning PEP8 compliance.


