### PR TITLE
Trigger comparison

### DIFF
--- a/apscheduler/triggers/base.py
+++ b/apscheduler/triggers/base.py
@@ -8,6 +8,17 @@ class BaseTrigger(six.with_metaclass(ABCMeta)):
 
     __slots__ = ()
 
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+        for slot in self.__slots__:
+            if getattr(self, slot) != getattr(other, slot):
+                return False
+        return True
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     @abstractmethod
     def get_next_fire_time(self, previous_fire_time, now):
         """

--- a/apscheduler/triggers/cron/fields.py
+++ b/apscheduler/triggers/cron/fields.py
@@ -70,6 +70,9 @@ class BaseField(object):
     def __eq__(self, other):
         return isinstance(self, self.__class__) and self.expressions == other.expressions
 
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     def __str__(self):
         expr_strings = (str(e) for e in self.expressions)
         return ','.join(expr_strings)

--- a/apscheduler/triggers/date.py
+++ b/apscheduler/triggers/date.py
@@ -14,7 +14,7 @@ class DateTrigger(BaseTrigger):
     :param datetime.tzinfo|str timezone: time zone for ``run_date`` if it doesn't have one already
     """
 
-    __slots__ = 'run_date'
+    __slots__ = ('run_date',)
 
     def __init__(self, run_date=None, timezone=None):
         timezone = astimezone(timezone) or get_localzone()

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # coding: utf-8
 import os.path
 

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -390,3 +390,16 @@ class TestIntervalTrigger(object):
 
         for attr in IntervalTrigger.__slots__:
             assert getattr(trigger2, attr) == getattr(trigger, attr)
+
+    def test_comparison(self):
+        assert (CronTrigger('*', '*', '*', '*', '1', '*', '*', '*')
+                == CronTrigger('*', '*', '*', '*', '1', '*', '*', '*'))
+        assert (CronTrigger('*', '*', '*', '*', '1', '*', '*', '*')
+                != CronTrigger('*', '*', '*', '1', '*', '*', '*', '*'))
+        assert DateTrigger('1945-05-8') == DateTrigger('1945-05-08')
+        assert DateTrigger('1945-05-08') != DateTrigger('1945-05-09')
+        start_date = datetime.now()
+        assert (IntervalTrigger(weeks=1, start_date=start_date)
+                == IntervalTrigger(weeks=1, start_date=start_date))
+        assert (IntervalTrigger(weeks=1, start_date=start_date)
+                != IntervalTrigger(weeks=1, seconds=1, start_date=start_date))


### PR DESCRIPTION
i needed to test the results of a parsing function that returns triggers. though i could have done this in other ways, i felt it would be intuitive to compare with expected instances.

however, one could argue that start-, endtime and timezone for an interval shouldn't be considered. as from a common point of view an hourly interval equals an hourly interval regardless the place on earth (don't know about marsian timezones though) an when it started. in my use-case that would apply.

`__lt__`  etc. could also be implemented for date and interval.

there's also a patch that allows to invoke `setup.py` directly, what i usually do and perceive as common.