### PR TITLE
fix case where both qt4 and qt5 are installed

### DIFF
--- a/apscheduler/schedulers/qt.py
+++ b/apscheduler/schedulers/qt.py
@@ -4,7 +4,7 @@ from apscheduler.schedulers.base import BaseScheduler
 
 try:
     from PyQt5.QtCore import QObject, QTimer
-except ImportError:  # pragma: nocover
+except ImportError, RuntimeError:  # pragma: nocover
     try:
         from PyQt4.QtCore import QObject, QTimer
     except ImportError:


### PR DESCRIPTION
If both PyQt4 and PyQt5 are installed, but PyQt4 has already been imported the statement `from PyQt5.QtCore import QObject, QTimer` generates the following error:
```
RuntimeError: the PyQt5.QtCore and PyQt4.QtCore modules both wrap the QObject class
```
This PR fixes this by catching the RuntimeError generated and trying PyQt4. 