### PR TITLE
remove the module that have been imported before __import__

### DIFF
--- a/apscheduler/util.py
+++ b/apscheduler/util.py
@@ -9,6 +9,8 @@ from functools import partial
 from pytz import timezone, utc
 import six
 
+import sys
+
 try:
     from inspect import signature
 except ImportError:  # pragma: nocover
@@ -264,6 +266,9 @@ def ref_to_obj(ref):
         raise ValueError('Invalid reference')
 
     modulename, rest = ref.split(':', 1)
+
+    if modulename in sys.modules:
+        del sys.modules[modulename]
     try:
         obj = __import__(modulename, fromlist=[rest])
     except ImportError:


### PR DESCRIPTION
After I add a job to the jobstore, I want to modify the job, so I remove the job. After modify my job code, and then re-add the job, but the job did not take effect, it still the implementation of the old code, I found that the __import__ problem, so I deleted the previously imported module before __import__ and then re-imported the modified module with __import__.  After this modification as long as I modify the module, the code will immediately take effect, and will not be the implementation of the old code.