### PR TITLE
Fix memory leak when job raises an exception

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,10 @@ setup(
             'pytest-tornado'
         ],
         'testing:python_version == "2.7"': ['mock'],
-        'testing:python_version != "2.7"': ['pytest_asyncio < 0.6.0']
+        'testing:python_version != "2.7"': ['pytest_asyncio < 0.6.0'],
+        'testing-memleaks': [
+            'psutil',
+        ],
     },
     zip_safe=False,
     entry_points={

--- a/tests/test_executors.py
+++ b/tests/test_executors.py
@@ -142,12 +142,17 @@ def _calculate_vms():
     return sum(p.memory_info().vms for p in all_processes)
 
 
-def test_submit_job_memleak(mock_scheduler, executor, create_job, freeze_time, timezone):
+def test_submit_job_memleak(monkeypatch, mock_scheduler, executor, create_job, freeze_time):
     """
     Test that executor does not suffer from memory leak when dealing with traceback objects.
     See https://github.com/agronholm/apscheduler/issues/235
     """
+    import _pytest.logging
+
     pytest.importorskip('psutil')
+
+    # Patch LogCaptureHandler because it keeps record of traceback objects, preventing GC.
+    monkeypatch.setattr(_pytest.logging.LogCaptureHandler, 'emit', lambda *a, **k: None)
 
     mock_scheduler._dispatch_event = MagicMock()
     run_time = (freeze_time.current)

--- a/tests/test_executors.py
+++ b/tests/test_executors.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from threading import Event
 from types import TracebackType
 import os
+import sys
 import time
 
 import pytest
@@ -142,6 +143,10 @@ def _calculate_vms():
     return sum(p.memory_info().vms for p in all_processes)
 
 
+@pytest.mark.skipif(hasattr(sys, 'pypy_version_info'), reason="""\
+It's hard to predict when GC will happen on pypy.
+See http://doc.pypy.org/en/release-2.4.x/garbage_collection.html
+""")
 def test_submit_job_memleak(monkeypatch, mock_scheduler, executor, create_job, freeze_time):
     """
     Test that executor does not suffer from memory leak when dealing with traceback objects.

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ skip_missing_interpreters = true
 [testenv]
 commands = pytest {posargs}
 extras = testing
+    testing-memleaks
     asyncio
     gevent
     mongodb


### PR DESCRIPTION
Fixes #235.

It cleans traceback frames where required to avoid keeping cyclic references everywhere thus preventing GC from happening.

If you're concerned by the `__traceback__` cleanup for py3 (for performance reasons or because it might be a tiny tiny breaking change), I can implement the `__del__` way, but it's much more intrusive. Unless you have a better way around this.