### PR TITLE
Allow multiple spaces in crontab format

### DIFF
--- a/apscheduler/triggers/cron/__init__.py
+++ b/apscheduler/triggers/cron/__init__.py
@@ -95,7 +95,7 @@ class CronTrigger(BaseTrigger):
         :return: a :class:`~CronTrigger` instance
 
         """
-        values = expr.split(' ')
+        values = expr.split()
         if len(values) != 5:
             raise ValueError('Wrong number of fields; got {}, expected 5'.format(len(values)))
 

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -391,8 +391,11 @@ class TestCronTrigger(object):
          "timezone='Europe/Berlin')>"),
         ('0-14 * 14-28 jul fri',
          "<CronTrigger (month='jul', day='14-28', day_of_week='fri', hour='*', minute='0-14', "
+         "timezone='Europe/Berlin')>"),
+        (' 0-14   * 14-28   jul       fri',
+         "<CronTrigger (month='jul', day='14-28', day_of_week='fri', hour='*', minute='0-14', "
          "timezone='Europe/Berlin')>")
-    ], ids=['always', 'assorted'])
+    ], ids=['always', 'assorted', 'multiple_spaces_in_format'])
     def test_from_crontab(self, expr, expected_repr, timezone):
         trigger = CronTrigger.from_crontab(expr, timezone)
         assert repr(trigger) == expected_repr


### PR DESCRIPTION
I noticed in commit 39cb1a5f65a2d5970b9639e3e324ad7953d261f9 that expr.split(' ') was used i.s.o. expr.split().
If .split() is used; then it is also possible for multiple spaces to be added in between (or in front).

Simple example showcasing different behavior:

```python
>>> 'a  b'.split()
['a', 'b']
>>> 'a  b'.split(' ')
['a', '', 'b']
>>> ' a  b'.split(' ')
['', 'a', '', 'b']
>>> ' a  b'.split()
['a', 'b']
```

This pull request changes the code to use .split().