### PR TITLE
Prevent deadlocks in scheduler shutdown

### DIFF
--- a/apscheduler/schedulers/base.py
+++ b/apscheduler/schedulers/base.py
@@ -177,12 +177,13 @@ class BaseScheduler(six.with_metaclass(ABCMeta)):
 
         self.state = STATE_STOPPED
 
-        with self._jobstores_lock, self._executors_lock:
-            # Shut down all executors
+        # Shut down all executors
+        with self._executors_lock:
             for executor in six.itervalues(self._executors):
                 executor.shutdown(wait)
 
-            # Shut down all job stores
+        # Shut down all job stores
+        with self._jobstores_lock:
             for jobstore in six.itervalues(self._jobstores):
                 jobstore.shutdown()
 


### PR DESCRIPTION
By splitting up the executor lock and jobstore lock, this allows jobs
that are shutting down to query their state from the database (requiring
`self._jobstore_lock`) without causing a deadlock.

Since setting `self.state` above prevents new jobs from being added to the
executors as they shut down, breaking up these locks won't allow new
jobs to run while the scheduler is shutting down.