### PR TITLE
Fix test failing randomly

### DIFF
--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -335,7 +335,7 @@ class TestCronTrigger(object):
         for attr in CronTrigger.__slots__:
             assert getattr(trigger2, attr) == getattr(trigger, attr)
 
-    def test_jitter_produces_differrent_valid_results(self, timezone):
+    def test_jitter_produces_different_valid_results(self, timezone):
         trigger = CronTrigger(minute='*', jitter=5)
         now = timezone.localize(datetime(2017, 11, 12, 6, 55, 30))
 

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -558,12 +558,13 @@ class TestIntervalTrigger(object):
             assert getattr(trigger2, attr) == getattr(trigger, attr)
 
     def test_jitter_produces_different_valid_results(self, timezone):
-        trigger = IntervalTrigger(seconds=5, timezone=timezone, jitter=3)
+        epsilon = timedelta(seconds=1)
         now = datetime.now(timezone)
+        trigger = IntervalTrigger(seconds=5, timezone=timezone, start_date=now, jitter=3)
 
         results = set()
         for _ in range(0, 100):
-            next_fire_time = trigger.get_next_fire_time(None, now)
+            next_fire_time = trigger.get_next_fire_time(None, now + epsilon)
             results.add(next_fire_time)
             assert timedelta(seconds=2) <= (next_fire_time - now) <= timedelta(seconds=8)
         assert 1 < len(results)


### PR DESCRIPTION
This test happened to be failing for very low jitter values such as `-2.999…`. This is because `IntervalTrigger` takes its own `now` value as `start_date`, which is slightly different from the `now` value inside the test. Consequently, the next fire time calculated could have been in less than two seconds we didn't consider the same base value in the test as the trigger.