### PR TITLE
gevent is already available for Python 2.x and 3.x

### DIFF
--- a/docs/modules/schedulers/gevent.rst
+++ b/docs/modules/schedulers/gevent.rst
@@ -26,6 +26,3 @@ GeventScheduler uses gevent natively, so it doesn't require monkey patching. By 
    * - Example
      - ``examples/schedulers/gevent_.py``
        (`view online <https://github.com/agronholm/apscheduler/tree/master/examples/schedulers/gevent_.py>`_).
-
-.. tip:: Until there is an official Python 3 compatible release of gevent, you can use an
-   `unofficial port <https://github.com/fantix/gevent>`_.


### PR DESCRIPTION
I noticed this outdated tip in the docs - gevent already supports Python 3:

>gevent 1.3 runs on Python 2.7 and Python 3. Releases 3.4, 3.5 and 3.6 of Python 3 are supported.