### PR TITLE
Add milliseconds support for the interval scheduler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ docs/_build/
 build/
 virtualenv/
 example.sqlite
+.pytest_cache

--- a/apscheduler/triggers/interval.py
+++ b/apscheduler/triggers/interval.py
@@ -17,6 +17,7 @@ class IntervalTrigger(BaseTrigger):
     :param int hours: number of hours to wait
     :param int minutes: number of minutes to wait
     :param int seconds: number of seconds to wait
+    :param int milliseconds: number of milliseconds to wait
     :param datetime|str start_date: starting point for the interval calculation
     :param datetime|str end_date: latest possible date/time to trigger on
     :param datetime.tzinfo|str timezone: time zone to use for the date/time calculations
@@ -25,10 +26,10 @@ class IntervalTrigger(BaseTrigger):
 
     __slots__ = 'timezone', 'start_date', 'end_date', 'interval', 'interval_length', 'jitter'
 
-    def __init__(self, weeks=0, days=0, hours=0, minutes=0, seconds=0, start_date=None,
-                 end_date=None, timezone=None, jitter=None):
+    def __init__(self, weeks=0, days=0, hours=0, minutes=0, seconds=0, milliseconds=0,
+                 start_date=None, end_date=None, timezone=None, jitter=None):
         self.interval = timedelta(weeks=weeks, days=days, hours=hours, minutes=minutes,
-                                  seconds=seconds)
+                                  seconds=seconds, milliseconds=milliseconds)
         self.interval_length = timedelta_seconds(self.interval)
         if self.interval_length == 0:
             self.interval = timedelta(seconds=1)

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -549,8 +549,8 @@ class TestIntervalTrigger(object):
         """Test that the trigger is pickleable."""
 
         trigger = IntervalTrigger(weeks=2, days=6, minutes=13, seconds=2,
-                                  start_date=date(2016, 4, 3), timezone=timezone,
-                                  jitter=12)
+                                  milliseconds=534, start_date=date(2016, 4, 3),
+                                  timezone=timezone, jitter=12)
         data = pickle.dumps(trigger, 2)
         trigger2 = pickle.loads(data)
 


### PR DESCRIPTION
Because of the way you implemented this (using timedeltas), the change involves very few lines of code.

I opted out of implementing this as microseconds, as it is unlikely that a scheduler running on any normal computer could actually uphold microsecond precision.