### PR TITLE
Fix jobs with duplicate id when scheduler is not ran

### DIFF
--- a/apscheduler/schedulers/base.py
+++ b/apscheduler/schedulers/base.py
@@ -409,6 +409,14 @@ class BaseScheduler(six.with_metaclass(ABCMeta)):
         :rtype: Job
 
         """
+
+        # Check if job with `id` already exists if `id` is provided.
+        if id is not None and not replace_existing:
+            # `get_job` should return None if there is no job with this id
+            # else raise `ConflictingIdError`
+            if self.get_job(job_id=id, jobstore=jobstore) is not None:
+                raise ConflictingIdError(job_id=id)
+
         job_kwargs = {
             'trigger': self._create_trigger(trigger, trigger_args),
             'executor': executor,


### PR DESCRIPTION
ref: https://stackoverflow.com/questions/51787976/apscheduler-job-ids-why-are-jobs-allowed-to-share-ids/51791145

Duplicate jobs with the same id can be created if the scheduler has not start, we can check early to prevent it.