### PR TITLE
Import Iterable, Mapping from collections.abc

### DIFF
--- a/apscheduler/job.py
+++ b/apscheduler/job.py
@@ -1,9 +1,3 @@
-try:
-    # Importing ABCs from collections instead of collections.abc
-    # will stop working in Python 3.8.
-    from collections.abc import Iterable, Mapping
-except ImportError:
-    from collections import Iterable, Mapping
 from inspect import ismethod, isclass
 from uuid import uuid4
 
@@ -14,6 +8,10 @@ from apscheduler.util import (
     ref_to_obj, obj_to_ref, datetime_repr, repr_escape, get_callable_name, check_callable_args,
     convert_to_datetime)
 
+try:
+    from collections.abc import Iterable, Mapping
+except ImportError:
+    from collections import Iterable, Mapping
 
 class Job(object):
     """

--- a/apscheduler/job.py
+++ b/apscheduler/job.py
@@ -1,4 +1,9 @@
-from collections import Iterable, Mapping
+try:
+    # Importing ABCs from collections instead of collections.abc
+    # will stop working in Python 3.8.
+    from collections.abc import Iterable, Mapping
+except ImportError:
+    from collections import Iterable, Mapping
 from inspect import ismethod, isclass
 from uuid import uuid4
 

--- a/apscheduler/schedulers/base.py
+++ b/apscheduler/schedulers/base.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 
 from abc import ABCMeta, abstractmethod
-from collections import MutableMapping
 from threading import RLock
 from datetime import datetime, timedelta
 from logging import getLogger
@@ -26,6 +25,11 @@ from apscheduler.events import (
     EVENT_JOBSTORE_ADDED, EVENT_JOBSTORE_REMOVED, EVENT_ALL, EVENT_JOB_MODIFIED, EVENT_JOB_REMOVED,
     EVENT_JOB_ADDED, EVENT_EXECUTOR_ADDED, EVENT_EXECUTOR_REMOVED, EVENT_ALL_JOBS_REMOVED,
     EVENT_JOB_SUBMITTED, EVENT_JOB_MAX_INSTANCES, EVENT_SCHEDULER_RESUMED, EVENT_SCHEDULER_PAUSED)
+
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    from collections import MutableMapping
 
 #: constant indicating a scheduler's stopped state
 STATE_STOPPED = 0


### PR DESCRIPTION
```
.../lib/python3.7/site-packages/apscheduler/job.py:1
  .../lib/python3.7/site-packages/apscheduler/job.py:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import Iterable, Mapping
```