### PR TITLE
Update FAQ to Explain Common ValueErrors

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -37,7 +37,9 @@ You're receiving an error like the following::
    of <__main__.xxxxxxx object at xxxxxxxxxxxxx>>) could not be determined. Consider giving a textual reference (module:function 
    name) instead.  
 
-This means that the function you are attempting to schedule is nested within a class or within another function. Functions to be scheduled must reside at module level, and must be importable. Further, class methods and static methods are not schedulable. Try moving your function into a module (not ``__init__.py``) and make sure it is not nested within a class or other function.
+This means that the function you are attempting to schedule is nested within a class or within another function. Functions to be scheduled must reside at module level, and must be importable. Try moving your function into a module (not ``__init__.py``) and make sure it is not nested within a class or other function.
+
+Despite this, as of Python3, class methods and static methods are in fact schedulable. 
 
 How can I use APScheduler with uWSGI?
 =====================================


### PR DESCRIPTION
One of the most common questions on StackOverflow (and the issues page here) revolves around trying to store jobs in a persistent job store and getting ValueErrors. This addition hopes to head off those questions.