### PR TITLE
Implement issue #297 - Passing the scheduled start time to jobs

### DIFF
--- a/apscheduler/executors/base.py
+++ b/apscheduler/executors/base.py
@@ -120,6 +120,9 @@ def run_job(job, jobstore_alias, run_times, logger_name):
                 logger.warning('Run time of job "%s" was missed by %s', job, difference)
                 continue
 
+        if job.provide_scheduled_run_time:
+            job.kwargs["scheduled_run_time"] = run_time
+
         logger.info('Running job "%s" (scheduled at %s)', job, run_time)
         try:
             retval = job.func(*job.args, **job.kwargs)

--- a/apscheduler/schedulers/base.py
+++ b/apscheduler/schedulers/base.py
@@ -370,7 +370,7 @@ class BaseScheduler(six.with_metaclass(ABCMeta)):
     def add_job(self, func, trigger=None, args=None, kwargs=None, id=None, name=None,
                 misfire_grace_time=undefined, coalesce=undefined, max_instances=undefined,
                 next_run_time=undefined, jobstore='default', executor='default',
-                replace_existing=False, **trigger_args):
+                replace_existing=False, provide_scheduled_run_time=False, **trigger_args):
         """
         add_job(func, trigger=None, args=None, kwargs=None, id=None, \
             name=None, misfire_grace_time=undefined, coalesce=undefined, \
@@ -427,7 +427,8 @@ class BaseScheduler(six.with_metaclass(ABCMeta)):
             'misfire_grace_time': misfire_grace_time,
             'coalesce': coalesce,
             'max_instances': max_instances,
-            'next_run_time': next_run_time
+            'next_run_time': next_run_time,
+            'provide_scheduled_run_time': provide_scheduled_run_time
         }
         job_kwargs = dict((key, value) for key, value in six.iteritems(job_kwargs) if
                           value is not undefined)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,6 +91,7 @@ def job_defaults(timezone):
 def create_job(job_defaults, timezone):
     def create(**kwargs):
         kwargs.setdefault('scheduler', Mock(BaseScheduler, timezone=timezone))
+        kwargs.setdefault('provide_scheduled_run_time', False)
         job_kwargs = job_defaults.copy()
         job_kwargs.update(kwargs)
         job_kwargs['trigger'] = BlockingScheduler()._create_trigger(job_kwargs.pop('trigger'),

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -146,6 +146,21 @@ def test_private_modify_bad_kwargs(job):
     assert str(exc.value) == 'kwargs must be a dict-like object'
 
 
+def test_modify_scheduled_run_time_in_kwargs(create_job):
+    def test_f(scheduled_run_time):
+        return None
+    job = create_job(func=test_f, provide_scheduled_run_time=True)
+    exc = pytest.raises(Exception, job._modify, kwargs={"scheduled_run_time": "dummy"})
+    assert str(exc.value) == "'scheduled_run_time' is a reserved parameter name"
+
+
+def test_modify_bad_provide_scheduled_run_time(create_job):
+    def test_f(scheduled_run_time):
+        return None
+    exc = pytest.raises(Exception, create_job, func=test_f, provide_scheduled_run_time="dummy")
+    assert str(exc.value) == 'provide_scheduled_run_time must be a boolean'
+
+
 @pytest.mark.parametrize('value', [1, ''], ids=['integer', 'empty string'])
 def test_private_modify_bad_name(job, value):
     """
@@ -197,10 +212,10 @@ def test_private_modify_bad_argument(job):
 def test_getstate(job):
     state = job.__getstate__()
     assert state == dict(
-        version=1, trigger=job.trigger, executor='default', func='tests.test_job:dummyfunc',
+        version=2, trigger=job.trigger, executor='default', func='tests.test_job:dummyfunc',
         name=b'n\xc3\xa4m\xc3\xa9'.decode('utf-8'), args=(), kwargs={},
         id=b't\xc3\xa9st\xc3\xafd'.decode('utf-8'), misfire_grace_time=1, coalesce=False,
-        max_instances=1, next_run_time=None)
+        max_instances=1, next_run_time=None, provide_scheduled_run_time=False)
 
 
 def test_setstate(job, timezone):

--- a/tests/test_schedulers.py
+++ b/tests/test_schedulers.py
@@ -918,6 +918,7 @@ class SchedulerImplementationTestBase(object):
                                             start_scheduler):
         """Tests that job can receive scheduled run time (the "provide_scheduled_run_time"
         add_job parameter) """
+        freeze_time.set_increment(timedelta(seconds=0.2))
         start_scheduler()
         assert self.wait_event(eventqueue).code == EVENT_JOBSTORE_ADDED
         assert self.wait_event(eventqueue).code == EVENT_SCHEDULER_STARTED

--- a/tests/test_schedulers.py
+++ b/tests/test_schedulers.py
@@ -914,6 +914,27 @@ class SchedulerImplementationTestBase(object):
         assert event.retval == 3
         assert self.wait_event(eventqueue).code == EVENT_JOB_REMOVED
 
+    def test_job_provide_scheduled_run_time(self, scheduler, freeze_time, eventqueue,
+                                            start_scheduler):
+        """Tests that job can receive scheduled run time (the "provide_scheduled_run_time"
+        add_job parameter) """
+        start_scheduler()
+        assert self.wait_event(eventqueue).code == EVENT_JOBSTORE_ADDED
+        assert self.wait_event(eventqueue).code == EVENT_SCHEDULER_STARTED
+
+        def test_func(scheduled_run_time):
+            return scheduled_run_time
+
+        scheduler.add_job(test_func,
+                          provide_scheduled_run_time=True,
+                          run_date=freeze_time.get())
+
+        assert self.wait_event(eventqueue).code == EVENT_JOB_ADDED
+        event = self.wait_event(eventqueue)
+
+        assert event.code == EVENT_JOB_EXECUTED
+        assert event.retval == event.scheduled_run_time
+
     def test_shutdown(self, scheduler, eventqueue, start_scheduler):
         """Tests that shutting down the scheduler emits the proper event."""
         start_scheduler()


### PR DESCRIPTION
This PR implements the feature request from #297. Proposed changes were tested against py36, py37, py27 and flake8 with memjobstore and sqlalchemyjobstore stores. At the moment, unfortunately, I'm not able to test with mongo/redis/zookeeper/rethinkdb.