### PR TITLE
Crontab tweaks

### DIFF
--- a/apscheduler/triggers/cron/__init__.py
+++ b/apscheduler/triggers/cron/__init__.py
@@ -91,7 +91,7 @@ class CronTrigger(BaseTrigger):
                 is_default = True
 
             field_class = self.FIELDS_MAP[field_name]
-            field = field_class(field_name, exprs, is_default)
+            field = field_class(field_name, exprs, is_default, standard=self.standard)
             self.fields.append(field)
 
     @classmethod

--- a/apscheduler/triggers/cron/__init__.py
+++ b/apscheduler/triggers/cron/__init__.py
@@ -43,6 +43,14 @@ class CronTrigger(BaseTrigger):
         'second': BaseField
     }
 
+    MACROS = {
+        '@yearly': '0 0 1 1 *',
+        '@monthly': '0 0 1 * *',
+        '@weekly': '0 0 * * 0',
+        '@daily': '0 0 * * *',
+        '@hourly': '0 * * * *',
+    }
+
     __slots__ = 'timezone', 'start_date', 'end_date', 'fields', 'jitter'
 
     def __init__(self, year=None, month=None, day=None, week=None, day_of_week=None, hour=None,
@@ -88,13 +96,18 @@ class CronTrigger(BaseTrigger):
         Create a :class:`~CronTrigger` from a standard crontab expression.
 
         See https://en.wikipedia.org/wiki/Cron for more information on the format accepted here.
+        Some common macros is also supported. Available macros:
+          @yearl, @monthly, @weekly, @daily and @hourly.
 
-        :param expr: minute, hour, day of month, month, day of week
+        :param str expr: minute, hour, day of month, month, day of week. Or a macro.
         :param datetime.tzinfo|str timezone: time zone to use for the date/time calculations (
             defaults to scheduler timezone)
         :return: a :class:`~CronTrigger` instance
 
         """
+        if expr in cls.MACROS:
+            expr = cls.MACROS[expr]
+
         values = expr.split()
         if len(values) != 5:
             raise ValueError('Wrong number of fields; got {}, expected 5'.format(len(values)))

--- a/apscheduler/triggers/cron/__init__.py
+++ b/apscheduler/triggers/cron/__init__.py
@@ -121,8 +121,13 @@ class CronTrigger(BaseTrigger):
         if not strict:
             standard = None
 
-        return cls(minute=values[0], hour=values[1], day=values[2], month=values[3],
-                   day_of_week=values[4], timezone=timezone, standard=standard)
+        kwargs = {
+            key: values[idx]
+            for idx, key in enumerate(('minute', 'hour', 'day', 'month', 'day_of_week'))
+            if values[idx] != '?'
+        }
+
+        return cls(timezone=timezone, standard=standard, **kwargs)
 
     def _increment_field_value(self, dateval, fieldnum):
         """

--- a/apscheduler/triggers/cron/__init__.py
+++ b/apscheduler/triggers/cron/__init__.py
@@ -128,6 +128,9 @@ class CronTrigger(BaseTrigger):
             if values[idx] != '?'
         }
 
+        if kwargs.get('day') == 'L':
+            kwargs['day'] = 'last'
+
         return cls(timezone=timezone, standard=standard, **kwargs)
 
     def _increment_field_value(self, dateval, fieldnum):

--- a/apscheduler/triggers/cron/__init__.py
+++ b/apscheduler/triggers/cron/__init__.py
@@ -131,6 +131,17 @@ class CronTrigger(BaseTrigger):
         if kwargs.get('day') == 'L':
             kwargs['day'] = 'last'
 
+        if '#' in kwargs.get('day_of_week', ''):
+            if kwargs.get('day', '*') != '*':
+                # arguably, the WeekdayPositionExpression belongs to the day_of_week field
+                # rather than the day field...
+                raise ValueError(
+                    'Conflict: day_of_week expression {day_of_week!r} would go into the day field,'
+                    ' which already have the expression {day!r}'
+                    .format(**kwargs)
+                )
+            kwargs['day'] = kwargs.pop('day_of_week')
+
         return cls(timezone=timezone, standard=standard, **kwargs)
 
     def _increment_field_value(self, dateval, fieldnum):

--- a/apscheduler/triggers/cron/expressions.py
+++ b/apscheduler/triggers/cron/expressions.py
@@ -164,9 +164,9 @@ class MonthRangeExpression(RangeExpression):
 
 
 class WeekdayRangeExpression(RangeExpression):
-    value_re = re.compile(r'(?P<first>[a-z]+)(?:-(?P<last>[a-z]+))?', re.IGNORECASE)
+    value_re = re.compile(r'(?P<first>[a-z]+)(?:-(?P<last>[a-z]+))?(?:/(?P<step>\d+))?$', re.IGNORECASE)
 
-    def __init__(self, first, last=None, standard=None):
+    def __init__(self, first, last=None, step=None, standard=None):
         self.weekdays = weekdays(standard)
         try:
             first_num = self.weekdays.index(first.lower())
@@ -181,17 +181,24 @@ class WeekdayRangeExpression(RangeExpression):
         else:
             last_num = None
 
-        super(WeekdayRangeExpression, self).__init__(first_num, last_num, standard=standard)
+        super(WeekdayRangeExpression, self).__init__(first_num, last_num, step, standard=standard)
 
     def __str__(self):
         if self.last != self.first and self.last is not None:
-            return '%s-%s' % (self.weekdays[self.first], self.weekdays[self.last])
-        return self.weekdays[self.first]
+            range = '%s-%s' % (self.weekdays[self.first], self.weekdays[self.last])
+        else:
+            range = self.weekdays[self.first]
+
+        if self.step:
+            return '%s/%d' % (range, self.step)
+        return range
 
     def __repr__(self):
         args = ["'%s'" % self.weekdays[self.first]]
         if self.last != self.first and self.last is not None:
             args.append("'%s'" % self.weekdays[self.last])
+        if self.step:
+            args.append(str(self.step))
         return "%s(%s)" % (self.__class__.__name__, ', '.join(args))
 
 

--- a/apscheduler/triggers/cron/expressions.py
+++ b/apscheduler/triggers/cron/expressions.py
@@ -211,7 +211,7 @@ class WeekdayRangeExpression(RangeExpression):
 
 class WeekdayPositionExpression(AllExpression):
     options = ['1st', '2nd', '3rd', '4th', '5th', 'last']
-    value_re = re.compile(r'(?P<option_name>%s) +(?P<weekday_name>(?:\d+|\w+))' %
+    value_re = re.compile(r'(?P<option_name>%s) +(?P<weekday_name>(?:\d+|\w+))$' %
                           '|'.join(options), re.IGNORECASE)
 
     def __init__(self, option_name, weekday_name, standard=None):
@@ -258,7 +258,7 @@ class WeekdayPositionExpression(AllExpression):
 
 
 class LastDayOfMonthExpression(AllExpression):
-    value_re = re.compile(r'last', re.IGNORECASE)
+    value_re = re.compile(r'last$', re.IGNORECASE)
 
     def __init__(self, standard=None):
         super(LastDayOfMonthExpression, self).__init__(None, standard=standard)

--- a/apscheduler/triggers/cron/expressions.py
+++ b/apscheduler/triggers/cron/expressions.py
@@ -133,9 +133,9 @@ class RangeExpression(AllExpression):
 
 
 class MonthRangeExpression(RangeExpression):
-    value_re = re.compile(r'(?P<first>[a-z]+)(?:-(?P<last>[a-z]+))?', re.IGNORECASE)
+    value_re = re.compile(r'(?P<first>[a-z]+)(?:-(?P<last>[a-z]+))?(?:/(?P<step>\d+))?$', re.IGNORECASE)
 
-    def __init__(self, first, last=None, standard=None):
+    def __init__(self, first, last=None, step=None, standard=None):
         try:
             first_num = MONTHS.index(first.lower()) + 1
         except ValueError:
@@ -149,17 +149,24 @@ class MonthRangeExpression(RangeExpression):
         else:
             last_num = None
 
-        super(MonthRangeExpression, self).__init__(first_num, last_num, standard=standard)
+        super(MonthRangeExpression, self).__init__(first_num, last_num, step, standard=standard)
 
     def __str__(self):
         if self.last != self.first and self.last is not None:
-            return '%s-%s' % (MONTHS[self.first - 1], MONTHS[self.last - 1])
-        return MONTHS[self.first - 1]
+            range = '%s-%s' % (MONTHS[self.first - 1], MONTHS[self.last - 1])
+        else:
+            range = MONTHS[self.first - 1]
+
+        if self.step:
+            return '%s/%d' % (range, self.step)
+        return range
 
     def __repr__(self):
         args = ["'%s'" % MONTHS[self.first]]
         if self.last != self.first and self.last is not None:
             args.append("'%s'" % MONTHS[self.last - 1])
+        if self.step:
+            args.append(str(self.step))
         return "%s(%s)" % (self.__class__.__name__, ', '.join(args))
 
 

--- a/apscheduler/triggers/cron/expressions.py
+++ b/apscheduler/triggers/cron/expressions.py
@@ -255,6 +255,8 @@ class WeekdayPositionExpression(AllExpression):
     def get_next_value(self, date, field):
         # Figure out the weekday of the month's first day and the number of days in that month
         first_day_wday, last_day = monthrange(date.year, date.month)
+        if self.standard == 'POSIX.1-2017':
+            first_day_wday = (first_day_wday + 1) % 7
 
         # Calculate which day of the month is the first of the target weekdays
         first_hit_day = self.weekday - first_day_wday + 1

--- a/apscheduler/triggers/cron/expressions.py
+++ b/apscheduler/triggers/cron/expressions.py
@@ -10,13 +10,19 @@ __all__ = ('AllExpression', 'RangeExpression', 'WeekdayRangeExpression',
 
 
 WEEKDAYS = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']
+WEEKDAYS_POSIX = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat']
 MONTHS = ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec']
+
+
+def weekdays(standard):
+    return WEEKDAYS_POSIX if standard == 'POSIX.1-2017' else WEEKDAYS
 
 
 class AllExpression(object):
     value_re = re.compile(r'\*(?:/(?P<step>\d+))?$')
 
-    def __init__(self, step=None):
+    def __init__(self, step=None, standard=None):
+        self.standard = standard
         self.step = asint(step)
         if self.step == 0:
             raise ValueError('Increment must be higher than 0')
@@ -60,8 +66,8 @@ class RangeExpression(AllExpression):
     value_re = re.compile(
         r'(?P<first>\d+)(?:-(?P<last>\d+))?(?:/(?P<step>\d+))?$')
 
-    def __init__(self, first, last=None, step=None):
-        super(RangeExpression, self).__init__(step)
+    def __init__(self, first, last=None, step=None, standard=None):
+        super(RangeExpression, self).__init__(step, standard)
         first = asint(first)
         last = asint(last)
         if last is None and step is None:
@@ -129,7 +135,7 @@ class RangeExpression(AllExpression):
 class MonthRangeExpression(RangeExpression):
     value_re = re.compile(r'(?P<first>[a-z]+)(?:-(?P<last>[a-z]+))?', re.IGNORECASE)
 
-    def __init__(self, first, last=None):
+    def __init__(self, first, last=None, standard=None):
         try:
             first_num = MONTHS.index(first.lower()) + 1
         except ValueError:
@@ -143,7 +149,7 @@ class MonthRangeExpression(RangeExpression):
         else:
             last_num = None
 
-        super(MonthRangeExpression, self).__init__(first_num, last_num)
+        super(MonthRangeExpression, self).__init__(first_num, last_num, standard=standard)
 
     def __str__(self):
         if self.last != self.first and self.last is not None:
@@ -160,31 +166,32 @@ class MonthRangeExpression(RangeExpression):
 class WeekdayRangeExpression(RangeExpression):
     value_re = re.compile(r'(?P<first>[a-z]+)(?:-(?P<last>[a-z]+))?', re.IGNORECASE)
 
-    def __init__(self, first, last=None):
+    def __init__(self, first, last=None, standard=None):
+        self.weekdays = weekdays(standard)
         try:
-            first_num = WEEKDAYS.index(first.lower())
+            first_num = self.weekdays.index(first.lower())
         except ValueError:
             raise ValueError('Invalid weekday name "%s"' % first)
 
         if last:
             try:
-                last_num = WEEKDAYS.index(last.lower())
+                last_num = self.weekdays.index(last.lower())
             except ValueError:
                 raise ValueError('Invalid weekday name "%s"' % last)
         else:
             last_num = None
 
-        super(WeekdayRangeExpression, self).__init__(first_num, last_num)
+        super(WeekdayRangeExpression, self).__init__(first_num, last_num, standard=standard)
 
     def __str__(self):
         if self.last != self.first and self.last is not None:
-            return '%s-%s' % (WEEKDAYS[self.first], WEEKDAYS[self.last])
-        return WEEKDAYS[self.first]
+            return '%s-%s' % (self.weekdays[self.first], self.weekdays[self.last])
+        return self.weekdays[self.first]
 
     def __repr__(self):
-        args = ["'%s'" % WEEKDAYS[self.first]]
+        args = ["'%s'" % self.weekdays[self.first]]
         if self.last != self.first and self.last is not None:
-            args.append("'%s'" % WEEKDAYS[self.last])
+            args.append("'%s'" % self.weekdays[self.last])
         return "%s(%s)" % (self.__class__.__name__, ', '.join(args))
 
 
@@ -193,15 +200,16 @@ class WeekdayPositionExpression(AllExpression):
     value_re = re.compile(r'(?P<option_name>%s) +(?P<weekday_name>(?:\d+|\w+))' %
                           '|'.join(options), re.IGNORECASE)
 
-    def __init__(self, option_name, weekday_name):
-        super(WeekdayPositionExpression, self).__init__(None)
+    def __init__(self, option_name, weekday_name, standard=None):
+        super(WeekdayPositionExpression, self).__init__(None, standard=standard)
         try:
             self.option_num = self.options.index(option_name.lower())
         except ValueError:
             raise ValueError('Invalid weekday position "%s"' % option_name)
 
+        self.weekdays = weekdays(standard)
         try:
-            self.weekday = WEEKDAYS.index(weekday_name.lower())
+            self.weekday = self.weekdays.index(weekday_name.lower())
         except ValueError:
             raise ValueError('Invalid weekday name "%s"' % weekday_name)
 
@@ -228,18 +236,18 @@ class WeekdayPositionExpression(AllExpression):
                 self.option_num == other.option_num and self.weekday == other.weekday)
 
     def __str__(self):
-        return '%s %s' % (self.options[self.option_num], WEEKDAYS[self.weekday])
+        return '%s %s' % (self.options[self.option_num], self.weekdays[self.weekday])
 
     def __repr__(self):
         return "%s('%s', '%s')" % (self.__class__.__name__, self.options[self.option_num],
-                                   WEEKDAYS[self.weekday])
+                                   self.weekdays[self.weekday])
 
 
 class LastDayOfMonthExpression(AllExpression):
     value_re = re.compile(r'last', re.IGNORECASE)
 
-    def __init__(self):
-        super(LastDayOfMonthExpression, self).__init__(None)
+    def __init__(self, standard=None):
+        super(LastDayOfMonthExpression, self).__init__(None, standard=standard)
 
     def get_next_value(self, date, field):
         return monthrange(date.year, date.month)[1]

--- a/apscheduler/triggers/cron/fields.py
+++ b/apscheduler/triggers/cron/fields.py
@@ -27,9 +27,10 @@ class BaseField(object):
     REAL = True
     COMPILERS = [AllExpression, RangeExpression]
 
-    def __init__(self, name, exprs, is_default=False):
+    def __init__(self, name, exprs, is_default=False, standard=None):
         self.name = name
         self.is_default = is_default
+        self.standard = standard
         self.compile_expressions(exprs)
 
     def get_min(self, dateval):
@@ -61,7 +62,7 @@ class BaseField(object):
         for compiler in self.COMPILERS:
             match = compiler.value_re.match(expr)
             if match:
-                compiled_expr = compiler(**match.groupdict())
+                compiled_expr = compiler(standard=self.standard, **match.groupdict())
 
                 try:
                     compiled_expr.validate_range(self.name)
@@ -104,6 +105,10 @@ class DayOfWeekField(BaseField):
     COMPILERS = BaseField.COMPILERS + [WeekdayRangeExpression]
 
     def get_value(self, dateval):
+        if self.standard == 'POSIX.1-2017':
+            # 0=Sunday
+            return dateval.isoweekday() % 7
+
         return dateval.weekday()
 
 

--- a/docs/modules/triggers/cron.rst
+++ b/docs/modules/triggers/cron.rst
@@ -33,6 +33,8 @@ illustrate this behavior.
 .. note:: The behavior for omitted fields was changed in APScheduler 2.0.
           Omitted fields previously always defaulted to ``*``.
 
+When the value of the ``standard`` parameter is ``'POSIX.1-2017'``, the behaviour reflects more closely to that of crontab. Most notably, when specifying both ``day`` and ``day_of_week``, the job fill execute on either a matching date, or a matching weekday.
+
 
 Expression types
 ----------------
@@ -111,6 +113,12 @@ The :meth:`~apscheduler.schedulers.base.BaseScheduler.scheduled_job` decorator w
 To schedule a job using a standard crontab expression::
 
     sched.add_job(job_function, CronTrigger.from_crontab('0 0 1-15 may-aug *'))
+
+    # To be more crontab compliant, you may provide strict=True
+
+    # Runs at midnight every day between the 1st and 15th, and also on
+    # weekdays Monday through Friday on all other days (notice the day of week numbering, 0 is for Sunday)
+    sched.add_job(job_function, CronTrigger.from_crontab('0 0 1-15 * 1-5', strict=True))
 
 The ``jitter`` option enables you to add a random component to the execution time. This might be useful if you have
 multiple servers and don't want them to run a job at the exact same moment or if you want to prevent jobs from running

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -428,6 +428,15 @@ class TestCronTrigger(object):
         trigger = CronTrigger.from_crontab(expr, timezone)
         assert repr(trigger) == expected_repr
 
+    @pytest.mark.parametrize('expr, expected_repr', [
+        ('* * * * *',
+         "<CronTrigger (month='*', day='*', day_of_week='*', hour='*', minute='*', "
+         "standard='POSIX.1-2017', timezone='Europe/Berlin')>"),
+    ], ids=['always'])
+    def test_from_crontab_strict(self, expr, expected_repr, timezone):
+        trigger = CronTrigger.from_crontab(expr, timezone, strict=True)
+        assert repr(trigger) == expected_repr
+
 
 class TestDateTrigger(object):
     @pytest.mark.parametrize('run_date,alter_tz,previous,now,expected', [

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -405,8 +405,25 @@ class TestCronTrigger(object):
          "timezone='Europe/Berlin')>"),
         (' 0-14   * 14-28   jul       fri',
          "<CronTrigger (month='jul', day='14-28', day_of_week='fri', hour='*', minute='0-14', "
+         "timezone='Europe/Berlin')>"),
+        ('@yearly',
+         "<CronTrigger (month='1', day='1', day_of_week='*', hour='0', minute='0', "
+         "timezone='Europe/Berlin')>"),
+        ('@monthly',
+         "<CronTrigger (month='*', day='1', day_of_week='*', hour='0', minute='0', "
+         "timezone='Europe/Berlin')>"),
+        ('@weekly',
+         "<CronTrigger (month='*', day='*', day_of_week='0', hour='0', minute='0', "
+         "timezone='Europe/Berlin')>"),
+        ('@daily',
+         "<CronTrigger (month='*', day='*', day_of_week='*', hour='0', minute='0', "
+         "timezone='Europe/Berlin')>"),
+        ('@hourly',
+         "<CronTrigger (month='*', day='*', day_of_week='*', hour='*', minute='0', "
          "timezone='Europe/Berlin')>")
-    ], ids=['always', 'assorted', 'multiple_spaces_in_format'])
+    ], ids=['always', 'assorted', 'multiple_spaces_in_format',
+            'yearly', 'monthly', 'weekly', 'daily', 'hourly'
+    ])
     def test_from_crontab(self, expr, expected_repr, timezone):
         trigger = CronTrigger.from_crontab(expr, timezone)
         assert repr(trigger) == expected_repr

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -212,6 +212,24 @@ class TestCronTrigger(object):
         correct_next_date = timezone.localize(datetime(2009, 1, 28))
         assert trigger.get_next_fire_time(None, start_date) == correct_next_date
 
+    def test_cron_weekday_step(self, timezone):
+        trigger = CronTrigger(year=2009, month=1, day_of_week='0-4/2', timezone=timezone)
+        assert repr(trigger) == ("<CronTrigger (year='2009', month='1', day_of_week='0-4/2', "
+                                 "timezone='Europe/Berlin')>")
+        assert str(trigger) == "cron[year='2009', month='1', day_of_week='0-4/2']"
+        start_date = timezone.localize(datetime(2009, 1, 1))
+        correct_next_date = timezone.localize(datetime(2009, 1, 2))
+        assert trigger.get_next_fire_time(None, start_date) == correct_next_date
+
+    def test_cron_weekday_name_step(self, timezone):
+        trigger = CronTrigger(year=2009, month=1, day_of_week='mon-fri/2', timezone=timezone)
+        assert repr(trigger) == ("<CronTrigger (year='2009', month='1', day_of_week='mon-fri/2', "
+                                 "timezone='Europe/Berlin')>")
+        assert str(trigger) == "cron[year='2009', month='1', day_of_week='mon-fri/2']"
+        start_date = timezone.localize(datetime(2009, 1, 1))
+        correct_next_date = timezone.localize(datetime(2009, 1, 2))
+        assert trigger.get_next_fire_time(None, start_date) == correct_next_date
+
     def test_week_1(self, timezone):
         trigger = CronTrigger(year=2009, month=2, week=8, timezone=timezone)
         assert repr(trigger) == ("<CronTrigger (year='2009', month='2', week='8', "

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -212,6 +212,16 @@ class TestCronTrigger(object):
         correct_next_date = timezone.localize(datetime(2009, 1, 28))
         assert trigger.get_next_fire_time(None, start_date) == correct_next_date
 
+    def test_cron_weekday_positional_2(self, timezone):
+        trigger = CronTrigger(month='*/3', day='mon#1', hour='6', minute='0',
+                              standard='POSIX.1-2017', timezone=timezone)
+        assert repr(trigger) == ("<CronTrigger (month='*/3', day='1st mon', hour='6', minute='0', "
+                                 "standard='POSIX.1-2017', timezone='Europe/Berlin')>")
+        assert str(trigger) == "cron[month='*/3', day='1st mon', hour='6', minute='0']"
+        start_date = timezone.localize(datetime(2019, 7, 18))
+        correct_next_date = timezone.localize(datetime(2019, 10, 7, 6, 0, 0))
+        assert trigger.get_next_fire_time(None, start_date) == correct_next_date
+
     def test_cron_weekday_step(self, timezone):
         trigger = CronTrigger(year=2009, month=1, day_of_week='0-4/2', timezone=timezone)
         assert repr(trigger) == ("<CronTrigger (year='2009', month='1', day_of_week='0-4/2', "

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -420,9 +420,13 @@ class TestCronTrigger(object):
          "timezone='Europe/Berlin')>"),
         ('@hourly',
          "<CronTrigger (month='*', day='*', day_of_week='*', hour='*', minute='0', "
+         "timezone='Europe/Berlin')>"),
+        ('20 ? 1 ? ?',
+         "<CronTrigger (day='1', minute='20', "
          "timezone='Europe/Berlin')>")
     ], ids=['always', 'assorted', 'multiple_spaces_in_format',
-            'yearly', 'monthly', 'weekly', 'daily', 'hourly'
+            'yearly', 'monthly', 'weekly', 'daily', 'hourly',
+            'omitted_fields'
     ])
     def test_from_crontab(self, expr, expected_repr, timezone):
         trigger = CronTrigger.from_crontab(expr, timezone)

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -418,9 +418,12 @@ class TestCronTrigger(object):
         (dict(hour='0-24'), r"Error validating expression '0-24': the last value \(24\) is higher "
                             r"than the maximum value \(23\)"),
         (dict(day='0-3'), r"Error validating expression '0-3': the first value \(0\) is lower "
-                          r"than the minimum value \(1\)")
-    ], ids=['too_large_step_all', 'too_large_step_range', 'too_high_last', 'too_low_first'])
-    def test_invalid_ranges(self, values, expected):
+                          r"than the minimum value \(1\)"),
+        (dict(day='lasts'), r'Unrecognized expression "lasts" for field "day"'),
+        (dict(day='3rd mon here'), r'Unrecognized expression "3rd mon here" for field "day"')
+    ], ids=['too_large_step_all', 'too_large_step_range', 'too_high_last', 'too_low_first',
+            'invalid_day_lasts', 'invalid_weekday_position'])
+    def test_invalid_parameters(self, values, expected):
         pytest.raises(ValueError, CronTrigger, **values).match(expected)
 
     @pytest.mark.parametrize('expr, expected_repr', [

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -230,6 +230,15 @@ class TestCronTrigger(object):
         correct_next_date = timezone.localize(datetime(2009, 1, 2))
         assert trigger.get_next_fire_time(None, start_date) == correct_next_date
 
+    def test_cron_month_name_range_step(self, timezone):
+        trigger = CronTrigger(year=2009, month='feb-aug/3', timezone=timezone)
+        assert repr(trigger) == ("<CronTrigger (year='2009', month='feb-aug/3', "
+                                 "timezone='Europe/Berlin')>")
+        assert str(trigger) == "cron[year='2009', month='feb-aug/3']"
+        start_date = timezone.localize(datetime(2009, 1, 1))
+        correct_next_date = timezone.localize(datetime(2009, 2, 1))
+        assert trigger.get_next_fire_time(None, start_date) == correct_next_date
+
     def test_week_1(self, timezone):
         trigger = CronTrigger(year=2009, month=2, week=8, timezone=timezone)
         assert repr(trigger) == ("<CronTrigger (year='2009', month='2', week='8', "

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -449,8 +449,12 @@ class TestCronTrigger(object):
          (2019, 2, 1, 8, 0, 0)),
         ('0 8 5-10 feb thu',
          "cron[month='feb', day='5-10', day_of_week='thu', hour='8', minute='0']",
-         (2019, 2, 5, 8, 0, 0))
-    ], ids=['any wednesday', 'day 10-20 and fridays', 'day 5-10 and thursdays'])
+         (2019, 2, 5, 8, 0, 0)),
+        ('0 8 * mar 1-5',
+         "cron[month='mar', day='*', day_of_week='1-5', hour='8', minute='0']",
+         (2019, 3, 1, 8, 0, 0))
+    ], ids=['any wednesday', 'day 10-20 and fridays', 'day 5-10 and thursdays',
+            'weekdays-offset'])
     def test_from_crontab_strict_weekdays(self, expr, expected_str, next_date, timezone):
         trigger = CronTrigger.from_crontab(expr, timezone=timezone, strict=True)
         assert str(trigger) == expected_str

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -453,10 +453,12 @@ class TestCronTrigger(object):
          "timezone='Europe/Berlin')>"),
         ('20 ? 1 ? ?',
          "<CronTrigger (day='1', minute='20', "
-         "timezone='Europe/Berlin')>")
+         "timezone='Europe/Berlin')>"),
+        ('? ? L ? ?',
+         "<CronTrigger (day='last', timezone='Europe/Berlin')>")
     ], ids=['always', 'assorted', 'multiple_spaces_in_format',
             'yearly', 'monthly', 'weekly', 'daily', 'hourly',
-            'omitted_fields'])
+            'omitted_fields', 'last_day_in_month'])
     def test_from_crontab(self, expr, expected_repr, timezone):
         trigger = CronTrigger.from_crontab(expr, timezone)
         assert repr(trigger) == expected_repr


### PR DESCRIPTION
I ran into some issues where we need the crontab syntax to be more in line with the standard, so the output (actual run times for the job) aligns with what other tools say they would given a crontab expression.

This PR also addresses some cosmetics (adds support for `@macro` expressions as a short-hand for a full expression)

The two most notable fixes is support for day of week 0 being Sunday, and that when you specify both day of month _and_ day of week, you should run when either of them match, not both.

All changes should be transparent (fully backwards compatible). If you don't use "strict" mode, there is no changed behaviour.