### PR TITLE
Properly unwrap partial async functions to direct them to the correct async scheduler.

### DIFF
--- a/apscheduler/executors/asyncio.py
+++ b/apscheduler/executors/asyncio.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import sys
 
-
 from apscheduler.executors.base import BaseExecutor, run_job
 from apscheduler.util import iscoroutinefunction_partial
 

--- a/apscheduler/executors/asyncio.py
+++ b/apscheduler/executors/asyncio.py
@@ -2,7 +2,9 @@ from __future__ import absolute_import
 
 import sys
 
+
 from apscheduler.executors.base import BaseExecutor, run_job
+from apscheduler.util import iscoroutinefunction_partial
 
 try:
     from asyncio import iscoroutinefunction
@@ -46,7 +48,7 @@ class AsyncIOExecutor(BaseExecutor):
             else:
                 self._run_job_success(job.id, events)
 
-        if iscoroutinefunction(job.func):
+        if iscoroutinefunction_partial(job.func):
             if run_coroutine_job is not None:
                 coro = run_coroutine_job(job, job._jobstore_alias, run_times, self._logger.name)
                 f = self._eventloop.create_task(coro)

--- a/apscheduler/executors/asyncio.py
+++ b/apscheduler/executors/asyncio.py
@@ -6,10 +6,8 @@ from apscheduler.executors.base import BaseExecutor, run_job
 from apscheduler.util import iscoroutinefunction_partial
 
 try:
-    from asyncio import iscoroutinefunction
     from apscheduler.executors.base_py3 import run_coroutine_job
 except ImportError:
-    from trollius import iscoroutinefunction
     run_coroutine_job = None
 
 

--- a/apscheduler/executors/tornado.py
+++ b/apscheduler/executors/tornado.py
@@ -8,13 +8,11 @@ from tornado.gen import convert_yielded
 from apscheduler.executors.base import BaseExecutor, run_job
 
 try:
-    from inspect import iscoroutinefunction
     from apscheduler.executors.base_py3 import run_coroutine_job
+    from apscheduler.util import iscoroutinefunction_partial
 except ImportError:
-    def iscoroutinefunction(func):
+    def iscoroutinefunction_partial(func):
         return False
-
-from apscheduler.util import iscoroutinefunction_partial
 
 
 class TornadoExecutor(BaseExecutor):

--- a/apscheduler/executors/tornado.py
+++ b/apscheduler/executors/tornado.py
@@ -14,6 +14,8 @@ except ImportError:
     def iscoroutinefunction(func):
         return False
 
+from apscheduler.util import iscoroutinefunction_partial
+
 
 class TornadoExecutor(BaseExecutor):
     """
@@ -44,7 +46,7 @@ class TornadoExecutor(BaseExecutor):
             else:
                 self._run_job_success(job.id, events)
 
-        if iscoroutinefunction(job.func):
+        if iscoroutinefunction_partial(job.func):
             f = run_coroutine_job(job, job._jobstore_alias, run_times, self._logger.name)
         else:
             f = self.executor.submit(run_job, job, job._jobstore_alias, run_times,

--- a/apscheduler/util.py
+++ b/apscheduler/util.py
@@ -6,7 +6,6 @@ from datetime import date, datetime, time, timedelta, tzinfo
 from calendar import timegm
 from functools import partial
 from inspect import isclass, ismethod
-import asyncio
 import re
 
 from pytz import timezone, utc, FixedOffset
@@ -21,6 +20,11 @@ try:
     from threading import TIMEOUT_MAX
 except ImportError:
     TIMEOUT_MAX = 4294967  # Maximum value accepted by Event.wait() on Windows
+
+try:
+    from asyncio import iscoroutinefunction
+except ImportError:
+    from trollius import iscoroutinefunction
 
 __all__ = ('asint', 'asbool', 'astimezone', 'convert_to_datetime', 'datetime_to_utc_timestamp',
            'utc_timestamp_to_datetime', 'timedelta_seconds', 'datetime_ceil', 'get_callable_name',
@@ -418,4 +422,4 @@ def iscoroutinefunction_partial(f):
 
     # The asyncio version of iscoroutinefunction includes testing for @coroutine
     # decorations vs. the inspect version which does not.
-    return asyncio.iscoroutinefunction(f)
+    return iscoroutinefunction(f)

--- a/apscheduler/util.py
+++ b/apscheduler/util.py
@@ -5,7 +5,8 @@ from __future__ import division
 from datetime import date, datetime, time, timedelta, tzinfo
 from calendar import timegm
 from functools import partial
-from inspect import isclass, ismethod, iscoroutinefunction
+from inspect import isclass, ismethod
+import asyncio
 import re
 
 from pytz import timezone, utc, FixedOffset
@@ -414,4 +415,7 @@ def check_callable_args(func, args, kwargs):
 def iscoroutinefunction_partial(f):
     while isinstance(f, partial):
         f = f.func
-    return iscoroutinefunction(f)
+
+    # The asyncio version of iscoroutinefunction includes testing for @coroutine
+    # decorations vs. the inspect version which does not.
+    return asyncio.iscoroutinefunction(f)

--- a/apscheduler/util.py
+++ b/apscheduler/util.py
@@ -5,7 +5,7 @@ from __future__ import division
 from datetime import date, datetime, time, timedelta, tzinfo
 from calendar import timegm
 from functools import partial
-from inspect import isclass, ismethod
+from inspect import isclass, ismethod, iscoroutinefunction
 import re
 
 from pytz import timezone, utc, FixedOffset
@@ -409,3 +409,9 @@ def check_callable_args(func, args, kwargs):
         raise ValueError(
             'The target callable does not accept the following keyword arguments: %s' %
             ', '.join(unmatched_kwargs))
+
+
+def iscoroutinefunction_partial(f):
+    while isinstance(f, partial):
+        f = f.func
+    return iscoroutinefunction(f)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -13,7 +13,9 @@ from apscheduler.job import Job
 from apscheduler.util import (
     asint, asbool, astimezone, convert_to_datetime, datetime_to_utc_timestamp,
     utc_timestamp_to_datetime, timedelta_seconds, datetime_ceil, get_callable_name, obj_to_ref,
-    ref_to_obj, maybe_ref, check_callable_args, datetime_repr, repr_escape)
+    ref_to_obj, maybe_ref, check_callable_args, datetime_repr, repr_escape,
+    iscoroutinefunction_partial
+)
 from tests.conftest import minpython, maxpython
 
 try:
@@ -355,3 +357,22 @@ class TestCheckCallableArgs(object):
         exc = pytest.raises(ValueError, check_callable_args, func, [1], {})
         assert str(exc.value) == ('The following keyword-only arguments have not been supplied in '
                                   'kwargs: y')
+
+
+def not_a_coro(x):
+    pass
+
+
+async def a_coro(x):
+    pass
+
+
+class TestIsCoroutineFunctionPartial(object):
+    def test_non_coro(self):
+        assert iscoroutinefunction_partial(not_a_coro) is False
+
+    def test_coro(self):
+        assert iscoroutinefunction_partial(a_coro) is True
+
+    def test_coro_partial(self):
+        assert iscoroutinefunction_partial(partial(a_coro, 1)) is True

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -359,20 +359,20 @@ class TestCheckCallableArgs(object):
                                   'kwargs: y')
 
 
-def not_a_coro(x):
-    pass
-
-
-async def a_coro(x):
-    pass
-
-
 class TestIsCoroutineFunctionPartial(object):
+    @staticmethod
+    def not_a_coro(x):
+        pass
+
+    @staticmethod
+    async def a_coro(x):
+        pass
+
     def test_non_coro(self):
-        assert iscoroutinefunction_partial(not_a_coro) is False
+        assert not iscoroutinefunction_partial(self.not_a_coro)
 
     def test_coro(self):
-        assert iscoroutinefunction_partial(a_coro) is True
+        assert iscoroutinefunction_partial(self.a_coro)
 
     def test_coro_partial(self):
-        assert iscoroutinefunction_partial(partial(a_coro, 1)) is True
+        assert iscoroutinefunction_partial(partial(self.a_coro, 1))

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -13,9 +13,7 @@ from apscheduler.job import Job
 from apscheduler.util import (
     asint, asbool, astimezone, convert_to_datetime, datetime_to_utc_timestamp,
     utc_timestamp_to_datetime, timedelta_seconds, datetime_ceil, get_callable_name, obj_to_ref,
-    ref_to_obj, maybe_ref, check_callable_args, datetime_repr, repr_escape,
-    iscoroutinefunction_partial
-)
+    ref_to_obj, maybe_ref, check_callable_args, datetime_repr, repr_escape)
 from tests.conftest import minpython, maxpython
 
 try:
@@ -357,22 +355,3 @@ class TestCheckCallableArgs(object):
         exc = pytest.raises(ValueError, check_callable_args, func, [1], {})
         assert str(exc.value) == ('The following keyword-only arguments have not been supplied in '
                                   'kwargs: y')
-
-
-class TestIsCoroutineFunctionPartial(object):
-    @staticmethod
-    def not_a_coro(x):
-        pass
-
-    @staticmethod
-    async def a_coro(x):
-        pass
-
-    def test_non_coro(self):
-        assert not iscoroutinefunction_partial(self.not_a_coro)
-
-    def test_coro(self):
-        assert iscoroutinefunction_partial(self.a_coro)
-
-    def test_coro_partial(self):
-        assert iscoroutinefunction_partial(partial(self.a_coro, 1))

--- a/tests/test_util_py35.py
+++ b/tests/test_util_py35.py
@@ -1,0 +1,22 @@
+from functools import partial
+
+from apscheduler.util import iscoroutinefunction_partial
+
+
+class TestIsCoroutineFunctionPartial:
+    @staticmethod
+    def not_a_coro(x):
+        pass
+
+    @staticmethod
+    async def a_coro(x):
+        pass
+
+    def test_non_coro(self):
+        assert not iscoroutinefunction_partial(self.not_a_coro)
+
+    def test_coro(self):
+        assert iscoroutinefunction_partial(self.a_coro)
+
+    def test_coro_partial(self):
+        assert iscoroutinefunction_partial(partial(self.a_coro, 1))

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,9 @@ extras = testing
     zookeeper
 deps = {py35,py36,py37}: PyQt5
 
+[testenv:py34]
+deps = twisted < 19.7
+
 [testenv:flake8]
 deps = flake8
 commands = flake8 apscheduler tests


### PR DESCRIPTION
Per #397 