### PR TITLE
Fixed reference cycle in run_coroutine_job

### DIFF
--- a/apscheduler/executors/base_py3.py
+++ b/apscheduler/executors/base_py3.py
@@ -33,6 +33,11 @@ async def run_coroutine_job(job, jobstore_alias, run_times, logger_name):
             events.append(JobExecutionEvent(EVENT_JOB_ERROR, job.id, jobstore_alias, run_time,
                                             exception=exc, traceback=formatted_tb))
             logger.exception('Job "%s" raised an exception', job)
+
+            # This is to prevent cyclic references that would lead to memory leaks
+            import traceback
+            traceback.clear_frames(tb)
+            del tb
         else:
             events.append(JobExecutionEvent(EVENT_JOB_EXECUTED, job.id, jobstore_alias, run_time,
                                             retval=retval))


### PR DESCRIPTION
For issue #406. This is using the code in apscheduler.executors.base.run_job.