### PR TITLE
zookeeper plugin support windows

### DIFF
--- a/apscheduler/jobstores/zookeeper.py
+++ b/apscheduler/jobstores/zookeeper.py
@@ -1,4 +1,3 @@
-import os
 import pickle
 from datetime import datetime
 
@@ -143,7 +142,7 @@ class ZooKeeperJobStore(BaseJobStore):
         all_ids = self.client.get_children(self.path)
         for node_name in all_ids:
             try:
-                node_path = self.path + "/" +node_name
+                node_path = self.path + "/" + node_name
                 content, _ = self.client.get(node_path)
                 doc = pickle.loads(content)
                 job_def = {

--- a/apscheduler/jobstores/zookeeper.py
+++ b/apscheduler/jobstores/zookeeper.py
@@ -20,9 +20,7 @@ class ZooKeeperJobStore(BaseJobStore):
     Stores jobs in a ZooKeeper tree. Any leftover keyword arguments are directly passed to
     kazoo's `KazooClient
     <http://kazoo.readthedocs.io/en/latest/api/client.html>`_.
-
     Plugin alias: ``zookeeper``
-
     :param str path: path to store jobs in
     :param client: a :class:`~kazoo.client.KazooClient` instance to use instead of
         providing connection arguments
@@ -59,7 +57,7 @@ class ZooKeeperJobStore(BaseJobStore):
 
     def lookup_job(self, job_id):
         self._ensure_paths()
-        node_path = os.path.join(self.path, job_id)
+        node_path = self.path + "/" + str(job_id)
         try:
             content, _ = self.client.get(node_path)
             doc = pickle.loads(content)
@@ -86,7 +84,7 @@ class ZooKeeperJobStore(BaseJobStore):
 
     def add_job(self, job):
         self._ensure_paths()
-        node_path = os.path.join(self.path,  str(job.id))
+        node_path = self.path + "/" + str(job.id)
         value = {
             'next_run_time': datetime_to_utc_timestamp(job.next_run_time),
             'job_state': job.__getstate__()
@@ -99,7 +97,7 @@ class ZooKeeperJobStore(BaseJobStore):
 
     def update_job(self, job):
         self._ensure_paths()
-        node_path = os.path.join(self.path,  str(job.id))
+        node_path = self.path + "/" + str(job.id)
         changes = {
             'next_run_time': datetime_to_utc_timestamp(job.next_run_time),
             'job_state': job.__getstate__()
@@ -112,7 +110,7 @@ class ZooKeeperJobStore(BaseJobStore):
 
     def remove_job(self, job_id):
         self._ensure_paths()
-        node_path = os.path.join(self.path,  str(job_id))
+        node_path = self.path + "/" + str(job_id)
         try:
             self.client.delete(node_path)
         except NoNodeError:
@@ -145,7 +143,7 @@ class ZooKeeperJobStore(BaseJobStore):
         all_ids = self.client.get_children(self.path)
         for node_name in all_ids:
             try:
-                node_path = os.path.join(self.path, node_name)
+                node_path = self.path + "/" +node_name
                 content, _ = self.client.get(node_path)
                 doc = pickle.loads(content)
                 job_def = {


### PR DESCRIPTION
function "os.path.join" return "\\" on windows, it can't work on zookeeper
replace os.path.join to "/", make apscheduler to support windows