### PR TITLE
Allow Job to be weak-referenced

### DIFF
--- a/apscheduler/job.py
+++ b/apscheduler/job.py
@@ -38,7 +38,7 @@ class Job:
 
     __slots__ = ('_scheduler', '_jobstore_alias', 'id', 'trigger', 'executor', 'func', 'func_ref',
                  'args', 'kwargs', 'name', 'misfire_grace_time', 'coalesce', 'max_instances',
-                 'next_run_time')
+                 'next_run_time', '__weakref__')
 
     def __init__(self, scheduler, id=None, **kwargs):
         super().__init__()

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -58,11 +58,13 @@ def test_remove(job):
     job.remove()
     job._scheduler.remove_job.assert_called_once_with(job.id, None)
 
+
 def test_weakref(create_job):
     job = create_job(func=dummyfunc)
     ref = weakref.ref(job)
     del job
     assert ref() is None
+
 
 def test_pending(job):
     """

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1,3 +1,4 @@
+import weakref
 from datetime import datetime, timedelta
 from functools import partial
 from unittest.mock import MagicMock, patch
@@ -57,6 +58,11 @@ def test_remove(job):
     job.remove()
     job._scheduler.remove_job.assert_called_once_with(job.id, None)
 
+def test_weakref(create_job):
+    job = create_job(func=dummyfunc)
+    ref = weakref.ref(job)
+    del job
+    assert ref() is None
 
 def test_pending(job):
     """

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -5,7 +5,6 @@ from functools import partial
 from types import ModuleType
 
 import pytest
-import pytz
 
 from apscheduler.util import (
     datetime_ceil, get_callable_name, obj_to_ref, ref_to_obj, maybe_ref, check_callable_args)


### PR DESCRIPTION
ATM, you can't weakref a job.
If a function in a job needs the job, it will cause circular reference.
Adding a `__weakref__` field will solve it.