### PR TITLE
remove a line

### DIFF
--- a/docs/modules/triggers/interval.rst
+++ b/docs/modules/triggers/interval.rst
@@ -54,8 +54,7 @@ You can use ``start_date`` and ``end_date`` to limit the total time in which the
 
 The :meth:`~apscheduler.schedulers.base.BaseScheduler.scheduled_job` decorator works nicely too::
 
-    from apscheduler.scheduler import BlockingScheduler
-
+    
     @sched.scheduled_job('interval', id='my_job_id', hours=2)
     def job_function():
         print("Hello World")


### PR DESCRIPTION
The line of "from apscheduler.scheduler import BlockingScheduler" is misleading. It doesn't seem to work correctly. 
Use "from apscheduler.schedulers.blocking import BlockingScheduler".