### PR TITLE
docs: fix simple typo, concurrenctly -> concurrently

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -337,7 +337,7 @@ UNRELEASED
 * Added optional job execution coalescing for situations where several
   executions of the job are due
 
-* Added an option to limit the maximum number of concurrenctly executing
+* Added an option to limit the maximum number of concurrently executing
   instances of the job
 
 * Allowed configuration of misfire grace times on a per-job basis


### PR DESCRIPTION
There is a small typo in docs/versionhistory.rst.

Should read `concurrently` rather than `concurrenctly`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md