### PR TITLE
Expose kwargs to underlying ThreadPool and ProcessPool executors

### DIFF
--- a/apscheduler/executors/pool.py
+++ b/apscheduler/executors/pool.py
@@ -44,12 +44,12 @@ class ThreadPoolExecutor(BasePoolExecutor):
     Plugin alias: ``threadpool``
 
     :param max_workers: the maximum number of spawned threads.
-    :param kwargs: dict of keyword arguments to pass to the underlying
+    :param pool_kwargs: dict of keyword arguments to pass to the underlying
         ThreadPoolExecutor constructor
     """
 
-    def __init__(self, max_workers=10, **kwargs):
-        pool = concurrent.futures.ThreadPoolExecutor(int(max_workers), **kwargs)
+    def __init__(self, max_workers=10, pool_kwargs={}):
+        pool = concurrent.futures.ThreadPoolExecutor(int(max_workers), **pool_kwargs)
         super(ThreadPoolExecutor, self).__init__(pool)
 
 
@@ -60,10 +60,10 @@ class ProcessPoolExecutor(BasePoolExecutor):
     Plugin alias: ``processpool``
 
     :param max_workers: the maximum number of spawned processes.
-    :param kwargs: dict of keyword arguments to pass to the underlying
+    :param pool_kwargs: dict of keyword arguments to pass to the underlying
         ProcessPoolExecutor constructor
     """
 
-    def __init__(self, max_workers=10, **kwargs):
-        pool = concurrent.futures.ProcessPoolExecutor(int(max_workers), **kwargs)
+    def __init__(self, max_workers=10, pool_kwargs={}):
+        pool = concurrent.futures.ProcessPoolExecutor(int(max_workers), **pool_kwargs)
         super(ProcessPoolExecutor, self).__init__(pool)

--- a/apscheduler/executors/pool.py
+++ b/apscheduler/executors/pool.py
@@ -48,7 +48,8 @@ class ThreadPoolExecutor(BasePoolExecutor):
         ThreadPoolExecutor constructor
     """
 
-    def __init__(self, max_workers=10, pool_kwargs={}):
+    def __init__(self, max_workers=10, pool_kwargs=None):
+        pool_kwargs = pool_kwargs or {}
         pool = concurrent.futures.ThreadPoolExecutor(int(max_workers), **pool_kwargs)
         super(ThreadPoolExecutor, self).__init__(pool)
 

--- a/apscheduler/executors/pool.py
+++ b/apscheduler/executors/pool.py
@@ -46,8 +46,8 @@ class ThreadPoolExecutor(BasePoolExecutor):
     :param max_workers: the maximum number of spawned threads.
     """
 
-    def __init__(self, max_workers=10):
-        pool = concurrent.futures.ThreadPoolExecutor(int(max_workers))
+    def __init__(self, max_workers=10, **kwargs):
+        pool = concurrent.futures.ThreadPoolExecutor(int(max_workers), **kwargs)
         super(ThreadPoolExecutor, self).__init__(pool)
 
 
@@ -60,6 +60,6 @@ class ProcessPoolExecutor(BasePoolExecutor):
     :param max_workers: the maximum number of spawned processes.
     """
 
-    def __init__(self, max_workers=10):
-        pool = concurrent.futures.ProcessPoolExecutor(int(max_workers))
+    def __init__(self, max_workers=10, **kwargs):
+        pool = concurrent.futures.ProcessPoolExecutor(int(max_workers), **kwargs)
         super(ProcessPoolExecutor, self).__init__(pool)

--- a/apscheduler/executors/pool.py
+++ b/apscheduler/executors/pool.py
@@ -65,6 +65,7 @@ class ProcessPoolExecutor(BasePoolExecutor):
         ProcessPoolExecutor constructor
     """
 
-    def __init__(self, max_workers=10, pool_kwargs={}):
+    def __init__(self, max_workers=10, pool_kwargs=None):
+        pool_kwargs = pool_kwargs or {}
         pool = concurrent.futures.ProcessPoolExecutor(int(max_workers), **pool_kwargs)
         super(ProcessPoolExecutor, self).__init__(pool)

--- a/apscheduler/executors/pool.py
+++ b/apscheduler/executors/pool.py
@@ -44,6 +44,8 @@ class ThreadPoolExecutor(BasePoolExecutor):
     Plugin alias: ``threadpool``
 
     :param max_workers: the maximum number of spawned threads.
+    :param kwargs: dict of keyword arguments to pass to the underlying
+        ThreadPoolExecutor constructor
     """
 
     def __init__(self, max_workers=10, **kwargs):
@@ -58,6 +60,8 @@ class ProcessPoolExecutor(BasePoolExecutor):
     Plugin alias: ``processpool``
 
     :param max_workers: the maximum number of spawned processes.
+    :param kwargs: dict of keyword arguments to pass to the underlying
+        ProcessPoolExecutor constructor
     """
 
     def __init__(self, max_workers=10, **kwargs):


### PR DESCRIPTION
Currently, there is no way to set some potentially important attributes in the underlying pool executors. This PR would allow a user to set these attributes.

Specifically, in my use case, I had an apscheduler app that used a lot of memory and delegated work to a ProcessPoolExecutor. Because the default mp_context for Unix is fork, this resulted in memory issues when the entire memory of my app was forked over to the new process.
https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods