### PR TITLE
[3.x] Fix pkg_resources deprecation - use importlib.metadata when available

### DIFF
--- a/apscheduler/__init__.py
+++ b/apscheduler/__init__.py
@@ -1,26 +1,15 @@
 import sys
-
-
-fallback_release = '3.5.0'
 if sys.version_info >= (3, 8):
-    from importlib.metadata import version, PackageNotFoundError
-
-    try:
-        release = version('APScheduler').split('-')[0]
-    except PackageNotFoundError:
-        release = fallback_release
-
-    del version, PackageNotFoundError
+    import importlib.metadata as importlib_metadata
 else:
-    from pkg_resources import get_distribution, DistributionNotFound
+    import importlib_metadata
 
-    try:
-        release = get_distribution('APScheduler').version.split('-')[0]
-    except DistributionNotFound:
-        release = fallback_release
 
-    del get_distribution, DistributionNotFound
+try:
+    release = importlib_metadata.version('APScheduler').split('-')[0]
+except importlib_metadata.PackageNotFoundError:
+    release = '3.5.0'
 
 version_info = tuple(int(x) if x.isdigit() else x for x in release.split('.'))
 version = __version__ = '.'.join(str(x) for x in version_info[:3])
-del sys, fallback_release
+del sys, importlib_metadata

--- a/apscheduler/__init__.py
+++ b/apscheduler/__init__.py
@@ -1,10 +1,26 @@
-from pkg_resources import get_distribution, DistributionNotFound
+import sys
 
-try:
-    release = get_distribution('APScheduler').version.split('-')[0]
-except DistributionNotFound:
-    release = '3.5.0'
+
+fallback_release = '3.5.0'
+if sys.version_info >= (3, 8):
+    from importlib.metadata import version, PackageNotFoundError
+
+    try:
+        release = version('APScheduler').split('-')[0]
+    except PackageNotFoundError:
+        release = fallback_release
+
+    del version, PackageNotFoundError
+else:
+    from pkg_resources import get_distribution, DistributionNotFound
+
+    try:
+        release = get_distribution('APScheduler').version.split('-')[0]
+    except DistributionNotFound:
+        release = fallback_release
+
+    del get_distribution, DistributionNotFound
 
 version_info = tuple(int(x) if x.isdigit() else x for x in release.split('.'))
 version = __version__ = '.'.join(str(x) for x in version_info[:3])
-del get_distribution, DistributionNotFound
+del sys, fallback_release

--- a/apscheduler/schedulers/base.py
+++ b/apscheduler/schedulers/base.py
@@ -7,7 +7,6 @@ from logging import getLogger
 import warnings
 import sys
 
-from pkg_resources import iter_entry_points
 from tzlocal import get_localzone
 import six
 
@@ -62,12 +61,28 @@ class BaseScheduler(six.with_metaclass(ABCMeta)):
 
     .. seealso:: :ref:`scheduler-config`
     """
+    if sys.version_info >= (3, 10):
+        from importlib.metadata import entry_points
 
-    _trigger_plugins = dict((ep.name, ep) for ep in iter_entry_points('apscheduler.triggers'))
+        _trigger_plugins = {ep.name: ep for ep in entry_points(group='apscheduler.triggers')}
+        _executor_plugins = {ep.name: ep for ep in entry_points(group='apscheduler.executors')}
+        _jobstore_plugins = {ep.name: ep for ep in entry_points(group='apscheduler.jobstores')}
+
+    elif sys.version_info >= (3, 8):
+        from importlib.metadata import entry_points
+
+        _trigger_plugins = {ep.name: ep for ep in entry_points()['apscheduler.triggers']}
+        _executor_plugins = {ep.name: ep for ep in entry_points()['apscheduler.executors']}
+        _jobstore_plugins = {ep.name: ep for ep in entry_points()['apscheduler.jobstores']}
+    else:
+        from pkg_resources import iter_entry_points
+
+        _trigger_plugins = {ep.name: ep for ep in iter_entry_points('apscheduler.triggers')}
+        _executor_plugins = {ep.name: ep for ep in iter_entry_points('apscheduler.executors')}
+        _jobstore_plugins = {ep.name: ep for ep in iter_entry_points('apscheduler.jobstores')}
+
     _trigger_classes = {}
-    _executor_plugins = dict((ep.name, ep) for ep in iter_entry_points('apscheduler.executors'))
     _executor_classes = {}
-    _jobstore_plugins = dict((ep.name, ep) for ep in iter_entry_points('apscheduler.jobstores'))
     _jobstore_classes = {}
 
     #

--- a/apscheduler/schedulers/base.py
+++ b/apscheduler/schedulers/base.py
@@ -30,6 +30,11 @@ try:
 except ImportError:
     from collections import MutableMapping
 
+try:
+    from importlib.metadata import entry_points
+except ModuleNotFoundError:
+    from importlib_metadata import entry_points
+
 #: constant indicating a scheduler's stopped state
 STATE_STOPPED = 0
 #: constant indicating a scheduler's running state (started and processing jobs)
@@ -61,25 +66,15 @@ class BaseScheduler(six.with_metaclass(ABCMeta)):
 
     .. seealso:: :ref:`scheduler-config`
     """
-    if sys.version_info >= (3, 10):
-        from importlib.metadata import entry_points
-
-        _trigger_plugins = {ep.name: ep for ep in entry_points(group='apscheduler.triggers')}
-        _executor_plugins = {ep.name: ep for ep in entry_points(group='apscheduler.executors')}
-        _jobstore_plugins = {ep.name: ep for ep in entry_points(group='apscheduler.jobstores')}
-
-    elif sys.version_info >= (3, 8):
-        from importlib.metadata import entry_points
-
+    # The `group=...` API is only available in the backport, used in <=3.7, and in std>=3.10.
+    if (3, 8) <= sys.version_info <= (3, 9):
         _trigger_plugins = {ep.name: ep for ep in entry_points()['apscheduler.triggers']}
         _executor_plugins = {ep.name: ep for ep in entry_points()['apscheduler.executors']}
         _jobstore_plugins = {ep.name: ep for ep in entry_points()['apscheduler.jobstores']}
     else:
-        from pkg_resources import iter_entry_points
-
-        _trigger_plugins = {ep.name: ep for ep in iter_entry_points('apscheduler.triggers')}
-        _executor_plugins = {ep.name: ep for ep in iter_entry_points('apscheduler.executors')}
-        _jobstore_plugins = {ep.name: ep for ep in iter_entry_points('apscheduler.jobstores')}
+        _trigger_plugins = {ep.name: ep for ep in entry_points(group='apscheduler.triggers')}
+        _executor_plugins = {ep.name: ep for ep in entry_points(group='apscheduler.executors')}
+        _jobstore_plugins = {ep.name: ep for ep in entry_points(group='apscheduler.jobstores')}
 
     _trigger_classes = {}
     _executor_classes = {}

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(
         'setuptools_scm'
     ],
     install_requires=[
-        'setuptools >= 0.7',
         'six >= 1.4.0',
         'pytz',
         'tzlocal >= 2.0, != 3.*',

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,8 @@ setup(
         'setuptools >= 0.7',
         'six >= 1.4.0',
         'pytz',
-        'tzlocal >= 2.0, != 3.*'
+        'tzlocal >= 2.0, != 3.*',
+        'importlib-metadata >= 3.6.0; python_version < "3.8"',
     ],
     extras_require={
         'gevent': ['gevent'],


### PR DESCRIPTION
Usage of `pkg_resources` now emits a deprecation warning (see [setuptools](https://github.com/pypa/setuptools/pull/3843)). It is also quite slow (just importing it).

Use `importlib.metadata` instead which is the recommended alternative.