### PR TITLE
fix(sqlalchemy) - testing 'update returning' was raising error on SQLite

### DIFF
--- a/src/apscheduler/datastores/sqlalchemy.py
+++ b/src/apscheduler/datastores/sqlalchemy.py
@@ -321,8 +321,10 @@ class SQLAlchemyDataStore(BaseExternalDataStore):
         # Find out if the dialect supports UPDATE...RETURNING
         async for attempt in self._retry():
             with attempt:
-                update = self.t_metadata.update().values(schema_version=1).returning(
-                    self.t_metadata.c.schema_version
+                update = (
+                    self.t_metadata.update()
+                    .values(schema_version=1)
+                    .returning(self.t_metadata.c.schema_version)
                 )
                 async with self._begin_transaction() as conn:
                     try:

--- a/src/apscheduler/datastores/sqlalchemy.py
+++ b/src/apscheduler/datastores/sqlalchemy.py
@@ -321,7 +321,7 @@ class SQLAlchemyDataStore(BaseExternalDataStore):
         # Find out if the dialect supports UPDATE...RETURNING
         async for attempt in self._retry():
             with attempt:
-                update = self.t_metadata.update().returning(
+                update = self.t_metadata.update().values(schema_version=1).returning(
                     self.t_metadata.c.schema_version
                 )
                 async with self._begin_transaction() as conn:

--- a/src/apscheduler/datastores/sqlalchemy.py
+++ b/src/apscheduler/datastores/sqlalchemy.py
@@ -323,7 +323,7 @@ class SQLAlchemyDataStore(BaseExternalDataStore):
             with attempt:
                 update = (
                     self.t_metadata.update()
-                    .values(schema_version=1)
+                    .values(schema_version=self.t_metadata.c.schema_version)
                     .returning(self.t_metadata.c.schema_version)
                 )
                 async with self._begin_transaction() as conn:


### PR DESCRIPTION
SET condition of UPDATE statement was not explicit. SQLite was not working.

Background:
```
2023-04-02T12:37:16+0200 PID:54053 {sqlalchemy.engine.Engine:2672} INFO - BEGIN (implicit)
2023-04-02T12:37:18+0200 PID:54053 {sqlalchemy.engine.Engine:1842} INFO - UPDATE metadata SET  RETURNING schema_version
2023-04-02T12:37:18+0200 PID:54053 {sqlalchemy.engine.Engine:1842} INFO - [generated in 0.00042s] ()
2023-04-02T12:37:20+0200 PID:54053 {sqlalchemy.engine.Engine:2675} INFO - ROLLBACK
2023-04-02T12:57:21+0200 PID:54053 {business.scheduling:61} ERROR - Unable to Create Schedule Object (sqlite3.OperationalError) near "RETURNING": syntax error [SQL: UPDATE metadata SET  RETURNING schema_version]
```