### PR TITLE
Fix the logic of the 'if' statement.

### DIFF
--- a/apscheduler/schedulers/base.py
+++ b/apscheduler/schedulers/base.py
@@ -67,7 +67,7 @@ class BaseScheduler(six.with_metaclass(ABCMeta)):
     .. seealso:: :ref:`scheduler-config`
     """
     # The `group=...` API is only available in the backport, used in <=3.7, and in std>=3.10.
-    if (3, 8) <= sys.version_info <= (3, 9):
+    if (3, 8) <= sys.version_info < (3, 10):
         _trigger_plugins = {ep.name: ep for ep in entry_points()['apscheduler.triggers']}
         _executor_plugins = {ep.name: ep for ep in entry_points()['apscheduler.executors']}
         _jobstore_plugins = {ep.name: ep for ep in entry_points()['apscheduler.jobstores']}


### PR DESCRIPTION
In the current logic, when the python version is 3.9.x, e.g. 3.9.6, it cannot into the first 'if' branch.