### PR TITLE
Fix `CronTrigger` deserialization for `JSONSerializer`

### DIFF
--- a/src/apscheduler/triggers/cron/__init__.py
+++ b/src/apscheduler/triggers/cron/__init__.py
@@ -68,7 +68,7 @@ class CronTrigger(Trigger):
     end_time: datetime | None = attrs.field(converter=as_aware_datetime, default=None)
     timezone: tzinfo = attrs.field(converter=as_timezone, factory=get_localzone)
     _fields: list[BaseField] = attrs.field(init=False, eq=False, factory=list)
-    _last_fire_time: datetime | None = attrs.field(init=False, eq=False, default=None)
+    _last_fire_time: datetime | None = attrs.field(converter=as_aware_datetime, init=False, eq=False, default=None)
 
     def __attrs_post_init__(self) -> None:
         self._set_fields(

--- a/src/apscheduler/triggers/cron/__init__.py
+++ b/src/apscheduler/triggers/cron/__init__.py
@@ -68,7 +68,9 @@ class CronTrigger(Trigger):
     end_time: datetime | None = attrs.field(converter=as_aware_datetime, default=None)
     timezone: tzinfo = attrs.field(converter=as_timezone, factory=get_localzone)
     _fields: list[BaseField] = attrs.field(init=False, eq=False, factory=list)
-    _last_fire_time: datetime | None = attrs.field(converter=as_aware_datetime, init=False, eq=False, default=None)
+    _last_fire_time: datetime | None = attrs.field(
+        converter=as_aware_datetime, init=False, eq=False, default=None
+    )
 
     def __attrs_post_init__(self) -> None:
         self._set_fields(

--- a/tests/triggers/test_cron.py
+++ b/tests/triggers/test_cron.py
@@ -89,10 +89,14 @@ def test_cron_trigger_1(timezone, serializer):
         start_time=start_time,
         timezone=timezone,
     )
+
+    # since `next` is modifying the trigger, we call it before serializing
+    # to make sure the serialization works correctly also for modified triggers
+    assert trigger.next() == datetime(2009, 1, 5, tzinfo=timezone)
+
     if serializer:
         trigger = serializer.deserialize(serializer.serialize(trigger))
 
-    assert trigger.next() == datetime(2009, 1, 5, tzinfo=timezone)
     assert trigger.next() == datetime(2009, 1, 6, tzinfo=timezone)
     assert trigger.next() == datetime(2009, 4, 5, tzinfo=timezone)
     assert trigger.next() == datetime(2009, 4, 6, tzinfo=timezone)


### PR DESCRIPTION
I noticed that the field `_last_fire_time` in `CronTrigger` is not properly deserialized when `JSONSerializer` is used, which causes the following error:
![image](https://github.com/agronholm/apscheduler/assets/1304915/86f7064b-3ce1-4f3c-aab4-81faca67d050)

I added a converter to ensure this field is always a valid `datetime`.