### PR TITLE
Enhanced typing of `subscribe()`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,12 +54,12 @@ test = [
     "anyio[trio]",
     "asyncmy >= 0.2.5; python_implementation == 'CPython'",
     "coverage >= 7",
-    "paho-mqtt >= 2.0",
+    "paho-mqtt >= 1.5",
     "psycopg",
     "pymongo >= 4",
     "pymysql[rsa]",
     "PySide6 >= 6.6; python_implementation == 'CPython'",
-    "pytest >= 8.0",
+    "pytest >= 7.4",
     "pytest-lazy-fixtures",
     "pytest-mock",
     "time-machine >= 2.13.0; python_implementation == 'CPython'",
@@ -132,4 +132,7 @@ commands = pyright --verifytypes apscheduler
 [testenv:docs]
 extras = doc
 commands = sphinx-build -n docs build/sphinx
+
+[testenv:paho-mqtt-v1]
+deps = paho-mqtt~=1.5
 """

--- a/src/apscheduler/_events.py
+++ b/src/apscheduler/_events.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from functools import partial
 from traceback import format_tb
-from typing import Any
+from typing import Any, TypeVar
 from uuid import UUID
 
 import attrs
@@ -13,6 +13,8 @@ from ._converters import as_aware_datetime, as_enum, as_uuid
 from ._enums import JobOutcome
 from ._structures import Job, JobResult
 from ._utils import qualified_name
+
+T_Event = TypeVar("T_Event", bound="Event")
 
 
 @attrs.define(kw_only=True, frozen=True)

--- a/src/apscheduler/_schedulers/async_.py
+++ b/src/apscheduler/_schedulers/async_.py
@@ -38,6 +38,7 @@ from .._events import (
     SchedulerStarted,
     SchedulerStopped,
     ScheduleUpdated,
+    T_Event,
 )
 from .._exceptions import (
     CallableLookupError,
@@ -216,8 +217,8 @@ class AsyncScheduler:
 
     def subscribe(
         self,
-        callback: Callable[[Event], Any],
-        event_types: type[Event] | Iterable[type[Event]] | None = None,
+        callback: Callable[[T_Event], Any],
+        event_types: type[T_Event] | Iterable[type[T_Event]] | None = None,
         *,
         one_shot: bool = False,
         is_async: bool = True,

--- a/src/apscheduler/_schedulers/async_.py
+++ b/src/apscheduler/_schedulers/async_.py
@@ -223,8 +223,7 @@ class AsyncScheduler:
         *,
         one_shot: bool = ...,
         is_async: bool = ...,
-    ) -> Subscription:
-        ...
+    ) -> Subscription: ...
 
     @overload
     def subscribe(
@@ -234,8 +233,7 @@ class AsyncScheduler:
         *,
         one_shot: bool = False,
         is_async: bool = True,
-    ) -> Subscription:
-        ...
+    ) -> Subscription: ...
 
     def subscribe(
         self,

--- a/src/apscheduler/_schedulers/async_.py
+++ b/src/apscheduler/_schedulers/async_.py
@@ -11,7 +11,7 @@ from functools import partial
 from inspect import isbuiltin, isclass, ismethod, ismodule
 from logging import Logger, getLogger
 from types import TracebackType
-from typing import Any, Callable, Iterable, Mapping, cast
+from typing import Any, Callable, Iterable, Mapping, cast, overload
 from uuid import UUID, uuid4
 
 import anyio
@@ -214,6 +214,28 @@ class AsyncScheduler:
         """Clean up expired job results and finished schedules."""
         await self.data_store.cleanup()
         self.logger.info("Cleaned up expired job results and finished schedules")
+
+    @overload
+    def subscribe(
+        self,
+        callback: Callable[[T_Event], Any],
+        event_types: type[T_Event],
+        *,
+        one_shot: bool = ...,
+        is_async: bool = ...,
+    ) -> Subscription:
+        ...
+
+    @overload
+    def subscribe(
+        self,
+        callback: Callable[[Event], Any],
+        event_types: Iterable[type[Event]] | None = None,
+        *,
+        one_shot: bool = False,
+        is_async: bool = True,
+    ) -> Subscription:
+        ...
 
     def subscribe(
         self,

--- a/src/apscheduler/_schedulers/sync.py
+++ b/src/apscheduler/_schedulers/sync.py
@@ -16,8 +16,8 @@ from uuid import UUID
 from anyio.from_thread import BlockingPortal, start_blocking_portal
 
 from .. import current_scheduler
-from .._events import T_Event
 from .._enums import CoalescePolicy, ConflictPolicy, RunState, SchedulerRole
+from .._events import T_Event
 from .._structures import Job, JobResult, Schedule, Task
 from .._utils import UnsetValue, unset
 from ..abc import DataStore, EventBroker, JobExecutor, Subscription, Trigger

--- a/src/apscheduler/_schedulers/sync.py
+++ b/src/apscheduler/_schedulers/sync.py
@@ -163,8 +163,7 @@ class Scheduler:
         event_types: type[T_Event],
         *,
         one_shot: bool = ...,
-    ) -> Subscription:
-        ...
+    ) -> Subscription: ...
 
     @overload
     def subscribe(
@@ -173,8 +172,7 @@ class Scheduler:
         event_types: Iterable[type[Event]] | None = None,
         *,
         one_shot: bool = False,
-    ) -> Subscription:
-        ...
+    ) -> Subscription: ...
 
     def subscribe(
         self,

--- a/src/apscheduler/_schedulers/sync.py
+++ b/src/apscheduler/_schedulers/sync.py
@@ -15,7 +15,8 @@ from uuid import UUID
 
 from anyio.from_thread import BlockingPortal, start_blocking_portal
 
-from .. import Event, current_scheduler
+from .. import current_scheduler
+from .._events import T_Event
 from .._enums import CoalescePolicy, ConflictPolicy, RunState, SchedulerRole
 from .._structures import Job, JobResult, Schedule, Task
 from .._utils import UnsetValue, unset
@@ -157,8 +158,8 @@ class Scheduler:
 
     def subscribe(
         self,
-        callback: Callable[[Event], Any],
-        event_types: Iterable[type[Event]] | None = None,
+        callback: Callable[[T_Event], Any],
+        event_types: Iterable[type[T_Event]] | None = None,
         *,
         one_shot: bool = False,
     ) -> Subscription:

--- a/src/apscheduler/abc.py
+++ b/src/apscheduler/abc.py
@@ -15,7 +15,7 @@ else:
 
 if TYPE_CHECKING:
     from ._enums import ConflictPolicy
-    from ._events import Event
+    from ._events import Event, T_Event
     from ._structures import Job, JobResult, Schedule, Task
 
 
@@ -135,8 +135,8 @@ class EventBroker(metaclass=ABCMeta):
     @abstractmethod
     def subscribe(
         self,
-        callback: Callable[[Event], Any],
-        event_types: Iterable[type[Event]] | None = None,
+        callback: Callable[[T_Event], Any],
+        event_types: Iterable[type[T_Event]] | None = None,
         *,
         is_async: bool = True,
         one_shot: bool = False,

--- a/src/apscheduler/eventbrokers/base.py
+++ b/src/apscheduler/eventbrokers/base.py
@@ -11,7 +11,7 @@ from anyio import CapacityLimiter, create_task_group, to_thread
 from anyio.abc import TaskGroup
 
 from .. import _events
-from .._events import Event
+from .._events import Event, T_Event
 from .._exceptions import DeserializationError
 from .._retry import RetryMixin
 from ..abc import EventBroker, Serializer, Subscription
@@ -47,8 +47,8 @@ class BaseEventBroker(EventBroker):
 
     def subscribe(
         self,
-        callback: Callable[[Event], Any],
-        event_types: Iterable[type[Event]] | None = None,
+        callback: Callable[[T_Event], Any],
+        event_types: Iterable[type[T_Event]] | None = None,
         *,
         is_async: bool = True,
         one_shot: bool = False,

--- a/src/apscheduler/eventbrokers/base.py
+++ b/src/apscheduler/eventbrokers/base.py
@@ -11,7 +11,7 @@ from anyio import CapacityLimiter, create_task_group, to_thread
 from anyio.abc import TaskGroup
 
 from .. import _events
-from .._events import Event, T_Event
+from .._events import Event
 from .._exceptions import DeserializationError
 from .._retry import RetryMixin
 from ..abc import EventBroker, Serializer, Subscription
@@ -47,8 +47,8 @@ class BaseEventBroker(EventBroker):
 
     def subscribe(
         self,
-        callback: Callable[[T_Event], Any],
-        event_types: Iterable[type[T_Event]] | None = None,
+        callback: Callable[[Event], Any],
+        event_types: Iterable[type[Event]] | None = None,
         *,
         is_async: bool = True,
         one_shot: bool = False,


### PR DESCRIPTION
This PR adds type var `T_Event` and uses it to type the `subscribe()` interfaces.

Fixes an issue where subscribing a handler would raise a type error if the handler is typed to receive a subclass of `Event`.

Allows type checkers to verify that the handler passed to `subscribe()` can support the event types it is assigned to handle.

Closes #846