### PR TITLE
Makes `__{a}exit__` method args nullable.

### DIFF
--- a/src/apscheduler/_schedulers/async_.py
+++ b/src/apscheduler/_schedulers/async_.py
@@ -169,9 +169,9 @@ class AsyncScheduler:
 
     async def __aexit__(
         self,
-        exc_type: type[BaseException],
-        exc_val: BaseException,
-        exc_tb: TracebackType,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
     ) -> None:
         await self.stop()
         await self._exit_stack.__aexit__(exc_type, exc_val, exc_tb)

--- a/src/apscheduler/_schedulers/sync.py
+++ b/src/apscheduler/_schedulers/sync.py
@@ -124,9 +124,9 @@ class Scheduler:
 
     def __exit__(
         self,
-        exc_type: type[BaseException],
-        exc_val: BaseException,
-        exc_tb: TracebackType,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
     ) -> None:
         if self._exit_stack:
             self._exit_stack.__exit__(exc_type, exc_val, exc_tb)


### PR DESCRIPTION
This makes the methods compatible with typeshed's ABCs: https://github.com/python/typeshed/blob/5e9589dd75f8a5f39a38a2ed45f098ff62babc7f/stdlib/contextlib.pyi#L40-L54

Closes #874