### PR TITLE
fix: remove extraneous arg in `RetryMixin`

### DIFF
--- a/src/apscheduler/_retry.py
+++ b/src/apscheduler/_retry.py
@@ -52,7 +52,7 @@ class RetryMixin:
         return ()
 
     def _retry(self) -> AsyncRetrying:
-        def after_attempt(self, retry_state: RetryCallState) -> None:
+        def after_attempt(retry_state: RetryCallState) -> None:
             self._logger.warning(
                 "Temporary data store error (attempt %d): %s",
                 retry_state.attempt_number,


### PR DESCRIPTION
Fixes https://github.com/agronholm/apscheduler/issues/879. Took the solution from https://github.com/agronholm/apscheduler/pull/760.