### PR TITLE
SQLAlchemy store should remove finished schedules on cleanup

### DIFF
--- a/src/apscheduler/datastores/sqlalchemy.py
+++ b/src/apscheduler/datastores/sqlalchemy.py
@@ -963,7 +963,7 @@ class SQLAlchemyDataStore(BaseExternalDataStore):
                     results = await self._execute(conn, query)
                     if finished_schedule_ids := dict(results.all()):
                         delete = self._t_schedules.delete().where(
-                            ~self._t_schedules.c.id.in_(finished_schedule_ids)
+                            self._t_schedules.c.id.in_(finished_schedule_ids)
                         )
                         await self._execute(conn, delete)
 

--- a/tests/test_schedulers.py
+++ b/tests/test_schedulers.py
@@ -698,7 +698,9 @@ class TestAsyncScheduler:
             await scheduler.start_in_background()
 
             # Add a job whose result expires after 1 ms
-            job_id = await scheduler.add_job(dummy_async_job, result_expiration_time=0.001)
+            job_id = await scheduler.add_job(
+                dummy_async_job, result_expiration_time=0.001
+            )
             with fail_after(3):
                 await event.wait()
 

--- a/tests/test_schedulers.py
+++ b/tests/test_schedulers.py
@@ -692,9 +692,7 @@ class TestAsyncScheduler:
         async with AsyncScheduler(raw_datastore, cleanup_interval=None) as scheduler:
             scheduler.subscribe(send.send, {ScheduleRemoved})
             event = anyio.Event()
-
             scheduler.subscribe(lambda _: event.set(), {JobReleased}, one_shot=True)
-
             await scheduler.start_in_background()
 
             # Add a job whose result expires after 1 ms
@@ -713,9 +711,7 @@ class TestAsyncScheduler:
 
             # Add a schedule to immediately set the event
             event = anyio.Event()
-
             scheduler.subscribe(lambda _: event.set(), {JobReleased}, one_shot=True)
-
             await scheduler.add_schedule(
                 dummy_async_job, DateTrigger(datetime.now(timezone.utc)), id="event_set"
             )


### PR DESCRIPTION
It looks like a typo error because a similar code in the mongodb/memory module deletes finished schedules. 

I have modified a test case for two reasons: 
1) it was not executed on all data stores 
2) the `anyio.Event()` is not serializable across different datastores, resulting in an error before execution.
