### PR TITLE
Add a webui project

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -118,6 +118,7 @@ incomplete list:
 * django_apscheduler_
 * apschedulerweb_
 * `Nextdoor scheduler`_
+* `apscheduler-webui`_
 
 .. _django_apscheduler: https://pypi.org/project/django-apscheduler/
 .. _Flask-APScheduler: https://pypi.org/project/flask-apscheduler/
@@ -125,3 +126,4 @@ incomplete list:
 .. _aiohttp: https://pypi.org/project/aiohttp/
 .. _apschedulerweb: https://github.com/marwinxxii/apschedulerweb
 .. _Nextdoor scheduler: https://github.com/Nextdoor/ndscheduler
+.. _apscheduler-webui: https://github.com/Dragon-GCS/apscheduler-webui


### PR DESCRIPTION
I love this scheduler project, and I've write a simple webui(https://github.com/Dragon-GCS/apscheduler-webui) for apscheduler based [FastUI](https://github.com/pydantic/FastUI). Can I put my project on FAQ?