### PR TITLE
fix RedisJobStore .add_job() .update_job() param error

### DIFF
--- a/apscheduler/jobstores/redis.py
+++ b/apscheduler/jobstores/redis.py
@@ -82,7 +82,7 @@ class RedisJobStore(BaseJobStore):
                                                           self.pickle_protocol))
             if job.next_run_time:
                 pipe.zadd(self.run_times_key,
-                          {job.id: datetime_to_utc_timestamp(job.next_run_time)})
+                          **{job.id: datetime_to_utc_timestamp(job.next_run_time)})
 
             pipe.execute()
 
@@ -95,7 +95,7 @@ class RedisJobStore(BaseJobStore):
                                                           self.pickle_protocol))
             if job.next_run_time:
                 pipe.zadd(self.run_times_key,
-                          {job.id: datetime_to_utc_timestamp(job.next_run_time)})
+                          **{job.id: datetime_to_utc_timestamp(job.next_run_time)})
             else:
                 pipe.zrem(self.run_times_key, job.id)
 

--- a/tests/test_schedulers.py
+++ b/tests/test_schedulers.py
@@ -1051,8 +1051,7 @@ class TestQtScheduler(SchedulerImplementationTestBase):
         return qt.QtScheduler()
 
     def wait_event(self, queue):
-        from PySide6.QtCore import QCoreApplication
-
+        QCoreApplication = pytest.importorskip('PySide6.QtCore.QCoreApplication')
         while queue.empty():
             QCoreApplication.processEvents()
         return queue.get_nowait()


### PR DESCRIPTION
redis zadd function score pairs should be specified in two ways:
  - As *args, in the form of: name1, score1, name2, score2, ...
  - or as **kwargs, in the form of: name1=score1, name2=score2, ...