### PR TITLE
refactor: Create `AsyncExitStack` using `attrs` factory

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -30,6 +30,8 @@ APScheduler, see the :doc:`migration section <migration>`.
   (PR by MohammadAmin Vahedinia)
 - Fixed the shutdown procedure of the Redis event broker
 - Fixed ``SQLAlchemyDataStore`` not respecting custom schema name when creating enums
+- Refactored ``AsyncScheduler`` to create ``AsyncExitStack`` using ``attrs`` factory
+  (PR by Justin Su)
 
 **4.0.0a4**
 


### PR DESCRIPTION
A bit nicer to have `attrs` create the `AsyncExitStack`, instead of assigning `self._exit_stack = exit_stack.pop_all()` from within the `with` block.