### PR TITLE
fix: Configure task with `misfire_grace_time` in `add_schedule()`

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -30,6 +30,7 @@ APScheduler, see the :doc:`migration section <migration>`.
   (PR by MohammadAmin Vahedinia)
 - Fixed the shutdown procedure of the Redis event broker
 - Fixed ``SQLAlchemyDataStore`` not respecting custom schema name when creating enums
+- Fixed missing ``misfire_grace_time`` argument in ``AsyncScheduler`` (PR by Justin Su)
 
 **4.0.0a4**
 

--- a/src/apscheduler/_schedulers/async_.py
+++ b/src/apscheduler/_schedulers/async_.py
@@ -472,6 +472,7 @@ class AsyncScheduler:
         task = await self.configure_task(
             func_or_task_id,
             job_executor=job_executor,
+            misfire_grace_time=misfire_grace_time,
             max_running_jobs=max_running_jobs,
         )
         schedule = Schedule(


### PR DESCRIPTION
`AsyncScheduler.add_schedule()` accepts a `misfire_grace_time` parameter, but was not passing it to `self.configure_task()`.

Fixes #863