### PR TITLE
Remove redundant `self._next_triggers` construction and add `AndTrigger` test.

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -30,6 +30,7 @@ APScheduler, see the :doc:`migration section <migration>`.
   (PR by MohammadAmin Vahedinia)
 - Fixed the shutdown procedure of the Redis event broker
 - Fixed ``SQLAlchemyDataStore`` not respecting custom schema name when creating enums
+- Fixed skipped intervals with overlapping schedules in ``AndTrigger``. (#911 <https://github.com/agronholm/apscheduler/issues/911>_; PR by Bennett Meares)
 
 **4.0.0a4**
 

--- a/src/apscheduler/triggers/combining.py
+++ b/src/apscheduler/triggers/combining.py
@@ -87,7 +87,6 @@ class AndTrigger(BaseCombiningTrigger):
 
             # If all the fire times were within the threshold, return the earliest one
             if latest_fire_time - earliest_fire_time <= self.threshold:
-                self._next_fire_times = [t.next() for t in self.triggers]
                 return earliest_fire_time
         else:
             raise MaxIterationsReached


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

Fixes #911. <!-- Provide issue number if exists -->

<!-- Please give a short brief about these changes. -->

When combining triggers (`IntervalTrigger`, `CronTrigger`, `CalendarIntervalTrigger`) with the `AndTrigger`, this patch ensures the expected datetimes are fired. The now-fixed bug was that every other interval was skipped in certain scenarios, such as when using `IntervalTrigger` with `days`.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue #999, the entry should look like this:

`* Fix big bad boo-boo in the async scheduler (#999
<https://github.com/agronholm/apscheduler/issues/999>_; PR by Yourname)`

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.

If possible, use your real name in the changelog entry. If not, use your GitHub
username.
