### PR TITLE
Fix wrong attrs dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ license = {text = "MIT"}
 requires-python = ">= 3.8"
 dependencies = [
     "anyio ~= 4.0",
-    "attrs >= 21.3",
+    "attrs >= 22.1",
     "tenacity ~= 8.0",
     "tzlocal >= 3.0",
     "typing_extensions >= 4.0; python_version < '3.11'"


### PR DESCRIPTION
`apscheduler` uses `attrs.validators.min_len` which has been added in `attrs` 22.1, see [relevant code](https://github.com/python-attrs/attrs/blob/main/src/attr/validators.py#L500-L509).

This PR fixes this mismatch.