### PR TITLE
Fix tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ test = [
     "pytest-mock",
     "time-machine >= 2.13.0; python_implementation == 'CPython'",
     """\
-    uwsgi; python_implementation == 'CPython' and platform_system == 'Linux'\
+    uwsgi <= 2.0.26; python_implementation == 'CPython' and platform_system == 'Linux'\
     and python_version < '3.13'\
     """,
 ]


### PR DESCRIPTION
Removed failed test that checked if the Scheduler was running on uwsgi with threads disabled. Now in new versions of uwsgi threads are enabled by default.

Reference to uwsgi change: https://github.com/unbit/uwsgi/commit/896ee575d0743e78237c7220007f4bbeaa8cedf8