### PR TITLE
Implement LastNDayOfMonthExpression

### DIFF
--- a/src/apscheduler/triggers/cron/expressions.py
+++ b/src/apscheduler/triggers/cron/expressions.py
@@ -251,3 +251,20 @@ class LastDayOfMonthExpression(AllExpression):
 
     def __str__(self) -> str:
         return "last"
+
+
+class LastNDayOfMonthExpression(AllExpression):
+    value_re = re.compile(r"last-(?P<last_day>[0-9]+)", re.IGNORECASE)
+
+    def __init__(self, last_day):
+        super(LastNDayOfMonthExpression, self).__init__(None)
+        self.last_day = as_int(last_day)
+
+    def get_next_value(self, date, field):
+        currval = field.get_value(date)
+        nextval = monthrange(date.year, date.month)[1]-self.last_day
+
+        return nextval if currval <= nextval else None
+
+    def __str__(self):
+        return f"last-{self.last_day}"

--- a/src/apscheduler/triggers/cron/fields.py
+++ b/src/apscheduler/triggers/cron/fields.py
@@ -13,6 +13,7 @@ from typing import Any, ClassVar
 from .expressions import (
     WEEKDAYS,
     AllExpression,
+    LastNDayOfMonthExpression,
     LastDayOfMonthExpression,
     MonthRangeExpression,
     RangeExpression,
@@ -122,7 +123,7 @@ class WeekField(BaseField, real=False):
 
 
 class DayOfMonthField(
-    BaseField, extra_compilers=(WeekdayPositionExpression, LastDayOfMonthExpression)
+    BaseField, extra_compilers=(WeekdayPositionExpression, LastNDayOfMonthExpression, LastDayOfMonthExpression)
 ):
     __slots__ = ()
 

--- a/tests/triggers/test_cron.py
+++ b/tests/triggers/test_cron.py
@@ -160,6 +160,22 @@ def test_cron_trigger_4(timezone, serializer):
     )
 
 
+def test_cron_trigger_5(timezone, serializer):
+    start_time = datetime(2012, 2, 1, tzinfo=timezone)
+    trigger = CronTrigger(
+        year="2012", month="2", day="last-6", start_time=start_time, timezone=timezone
+    )
+    if serializer:
+        trigger = serializer.deserialize(serializer.serialize(trigger))
+
+    assert trigger.next() == datetime(2012, 2, 23, tzinfo=timezone)
+    assert repr(trigger) == (
+        "CronTrigger(year='2012', month='2', day='last-6', week='*', "
+        "day_of_week='*', hour='0', minute='0', second='0', "
+        "start_time='2012-02-01T00:00:00+01:00', timezone='Europe/Berlin')"
+    )
+
+
 @pytest.mark.parametrize("expr", ["3-5", "wed-fri"], ids=["numeric", "text"])
 def test_weekday_overlap(timezone, serializer, expr):
     start_time = datetime(2009, 1, 1, tzinfo=timezone)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

Fixes #987. <!-- Provide issue number if exists -->

It is the implementation of LastNDayOfMonthExpression to support Nth-to-last day in a given month. For instance, I'd like to get the 2nd-to-last day in March.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [ ] You've added a new changelog entry (in `docs/versionhistory.rst`).


### Updating the changelog

`* Implement LastNDayOfMonthExpression  (#987 <https://github.com/agronholm/apscheduler/issues/987>; PR by @Cryingmouse)`

