### PR TITLE
Avoid crash when removing job which might not exist in async_.py

### DIFF
--- a/src/apscheduler/_schedulers/async_.py
+++ b/src/apscheduler/_schedulers/async_.py
@@ -1216,4 +1216,4 @@ class AsyncScheduler:
             finally:
                 current_job.reset(token)
         finally:
-            self._running_jobs.remove(job)
+            self._running_jobs.discard(job)


### PR DESCRIPTION
I found a scenario once though harder to reproduce that scheduler crashes when a job runs longer than the schedule which has an interval of say 1 minute. I believe the duration is lesser important, but it is possible that the job runs longer than 1 minute and when the time comes to remove it then it do not exist and calling python `set.remove(id)` crashes the scheduler which should not be so. Hence protecting it.

<!-- Thank you for your contribution! -->
## Changes

Fixes #. <!-- Provide issue number if exists -->

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [ ] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue #999, the entry should look like this:

`* Fix big bad boo-boo in the async scheduler (#999
<https://github.com/agronholm/apscheduler/issues/999>_; PR by @yourgithubaccount)`

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
