### PR TITLE
Add cooldown_period to OrTrigger

### DIFF
--- a/tests/triggers/test_combining.py
+++ b/tests/triggers/test_combining.py
@@ -200,11 +200,32 @@ class TestOrTrigger:
         # The end time of the 6 second interval has been reached
         assert trigger.next() is None
 
+    def test_cooldown_period(self, timezone, serializer):
+        start_time = datetime(2020, 5, 16, 14, 17, 30, 254212, tzinfo=timezone)
+        trigger = OrTrigger(
+            [
+                IntervalTrigger(seconds=4, start_time=start_time),
+                IntervalTrigger(seconds=6, start_time=start_time),
+            ],
+            cooldown_period=1,
+        )
+        if serializer:
+            trigger = serializer.deserialize(serializer.serialize(trigger))
+
+        assert trigger.next() == start_time
+        assert trigger.next() == start_time + timedelta(seconds=4)
+        assert trigger.next() == start_time + timedelta(seconds=6)
+        assert trigger.next() == start_time + timedelta(seconds=8)
+        assert trigger.next() == start_time + timedelta(seconds=12)  # No second trigger -> cooldown
+        assert trigger.next() == start_time + timedelta(seconds=16)
+        assert trigger.next() == start_time + timedelta(seconds=18)
+
     def test_repr(self, timezone):
         date1 = datetime(2020, 5, 16, 14, 17, 30, 254212, tzinfo=timezone)
         date2 = datetime(2020, 5, 18, 15, 1, 53, 940564, tzinfo=timezone)
-        trigger = OrTrigger([DateTrigger(date1), DateTrigger(date2)])
+        trigger = OrTrigger([DateTrigger(date1), DateTrigger(date2)], 1)
+        print(repr(trigger))
         assert repr(trigger) == (
             "OrTrigger([DateTrigger('2020-05-16 14:17:30.254212+02:00'), "
-            "DateTrigger('2020-05-18 15:01:53.940564+02:00')])"
+            "DateTrigger('2020-05-18 15:01:53.940564+02:00')], cooldown_period=1.0)"
         )

--- a/tests/triggers/test_combining.py
+++ b/tests/triggers/test_combining.py
@@ -216,7 +216,9 @@ class TestOrTrigger:
         assert trigger.next() == start_time + timedelta(seconds=4)
         assert trigger.next() == start_time + timedelta(seconds=6)
         assert trigger.next() == start_time + timedelta(seconds=8)
-        assert trigger.next() == start_time + timedelta(seconds=12)  # No second trigger -> cooldown
+        assert trigger.next() == start_time + timedelta(
+            seconds=12
+        )  # No second trigger -> cooldown
         assert trigger.next() == start_time + timedelta(seconds=16)
         assert trigger.next() == start_time + timedelta(seconds=18)
 
@@ -241,7 +243,11 @@ class TestOrTrigger:
     def test_repr(self, timezone):
         date1 = datetime(2020, 5, 16, 14, 17, 30, 254212, tzinfo=timezone)
         date2 = datetime(2020, 5, 18, 15, 1, 53, 940564, tzinfo=timezone)
-        trigger = OrTrigger([DateTrigger(date1), DateTrigger(date2)], cooldown_period=1, max_iterations=10000)
+        trigger = OrTrigger(
+            [DateTrigger(date1), DateTrigger(date2)],
+            cooldown_period=1,
+            max_iterations=10000,
+        )
         print(repr(trigger))
         assert repr(trigger) == (
             "OrTrigger([DateTrigger('2020-05-16 14:17:30.254212+02:00'), "

--- a/tests/triggers/test_combining.py
+++ b/tests/triggers/test_combining.py
@@ -220,12 +220,30 @@ class TestOrTrigger:
         assert trigger.next() == start_time + timedelta(seconds=16)
         assert trigger.next() == start_time + timedelta(seconds=18)
 
+    def test_max_iterations(self, timezone, serializer):
+        start_time = datetime(2020, 5, 16, 14, 17, 30, 254212, tzinfo=timezone)
+        trigger = OrTrigger(
+            [
+                IntervalTrigger(seconds=1, start_time=start_time),
+                IntervalTrigger(seconds=1, start_time=start_time),
+            ],
+            cooldown_period=100,
+            # Max iterations should be reached before the cooldown period
+            max_iterations=10,
+        )
+        if serializer:
+            trigger = serializer.deserialize(serializer.serialize(trigger))
+
+        # The triggers will keep firing after each other indefinitely
+        assert trigger.next() == start_time
+        pytest.raises(MaxIterationsReached, trigger.next)
+
     def test_repr(self, timezone):
         date1 = datetime(2020, 5, 16, 14, 17, 30, 254212, tzinfo=timezone)
         date2 = datetime(2020, 5, 18, 15, 1, 53, 940564, tzinfo=timezone)
-        trigger = OrTrigger([DateTrigger(date1), DateTrigger(date2)], 1)
+        trigger = OrTrigger([DateTrigger(date1), DateTrigger(date2)], cooldown_period=1, max_iterations=10000)
         print(repr(trigger))
         assert repr(trigger) == (
             "OrTrigger([DateTrigger('2020-05-16 14:17:30.254212+02:00'), "
-            "DateTrigger('2020-05-18 15:01:53.940564+02:00')], cooldown_period=1.0)"
+            "DateTrigger('2020-05-18 15:01:53.940564+02:00')], cooldown_period=1.0, max_iterations=10000)"
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

Fixes #453

- Added the `cooldown_period` attribute to the OrTrigger, preventing two triggers triggering within that interval.
- Added a `max_iterations` attribute to the OrTrigger as in the AndTrigger preventing near infinite looping when two triggers are triggering a lot whilst being in the cooldown phase.
- Added tests to confirm the behavior

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [ ] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue #999, the entry should look like this:

`* Fix big bad boo-boo in the async scheduler (#999
<https://github.com/agronholm/apscheduler/issues/999>_; PR by @yourgithubaccount)`

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
