### PR TITLE
Improve converters and type annotations

### DIFF
--- a/src/apscheduler/_converters.py
+++ b/src/apscheduler/_converters.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone, tzinfo
 from typing import Any
 from uuid import UUID
 from zoneinfo import ZoneInfo
@@ -9,14 +9,14 @@ from zoneinfo import ZoneInfo
 from tzlocal import get_localzone
 
 
-def as_int(value: Any) -> Any:
+def as_int(value: int | str) -> int:
     if isinstance(value, str):
         return int(value)
 
     return value
 
 
-def as_aware_datetime(value: Any) -> Any:
+def as_aware_datetime(value: datetime | str) -> datetime:
     if isinstance(value, str):
         # Before Python 3.11, fromisoformat() could not handle the "Z" suffix
         if value.upper().endswith("Z"):
@@ -30,33 +30,30 @@ def as_aware_datetime(value: Any) -> Any:
     return value
 
 
-def as_date(value: Any) -> Any:
+def as_date(value: date | str) -> date:
     if isinstance(value, str):
         return date.fromisoformat(value)
 
     return value
 
 
-def as_timezone(value: Any) -> Any:
+def as_timezone(value: tzinfo | str) -> tzinfo:
     if isinstance(value, str):
-        if value is None or value == "local":
-            return get_localzone()
-
-        return ZoneInfo(value)
+        return get_localzone() if value == "local" else ZoneInfo(value)
     elif value is timezone.utc:
         return ZoneInfo("UTC")
 
     return value
 
 
-def as_uuid(value: Any) -> Any:
+def as_uuid(value: UUID | str) -> UUID:
     if isinstance(value, str):
         return UUID(value)
 
     return value
 
 
-def as_timedelta(value: Any) -> Any:
+def as_timedelta(value: timedelta | int) -> timedelta:
     if isinstance(value, (float, int)):
         return timedelta(seconds=value)
 

--- a/src/apscheduler/_converters.py
+++ b/src/apscheduler/_converters.py
@@ -63,7 +63,7 @@ def as_timedelta(value: timedelta | int) -> timedelta:
 def as_enum(enum_class: Any) -> Callable[[Any], Any]:
     def converter(value: Any) -> Any:
         if isinstance(value, str):
-            return enum_class.__members__[value]
+            return enum_class[value]
 
         return value
 

--- a/src/apscheduler/triggers/cron/__init__.py
+++ b/src/apscheduler/triggers/cron/__init__.py
@@ -118,7 +118,7 @@ class CronTrigger(Trigger):
         *,
         start_time: datetime | None = None,
         end_time: datetime | None = None,
-        timezone: str | tzinfo = "local",
+        timezone: tzinfo | str = "local",
     ) -> CronTrigger:
         """
         Create a :class:`~CronTrigger` from a standard crontab expression.


### PR DESCRIPTION
## Changes

- Add proper type annotations to converters, instead of `Any`
- `as_timezone`: Remove unreachable `None` handling (fixes https://github.com/agronholm/apscheduler/issues/1013)
	- It doesn't make sense for `None` to do the same thing as the `"local"` default while being less explicit, so I omitted it from the type annotation and dropped the unreachable code
	- The current runtime behaviour is maintained, but a type checker will now warn you about it
- `CronTrigger.from_crontab`: Swap `timezone` parameter type annotation ordering to `tzinfo | str` for consistency
    - This ordering seems more logical than `str | tzinfo`
- `as_enum`: Use `Enum.__getitem__` instead of `Enum.__members__.__getitem__`

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [ ] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue #999, the entry should look like this:

`* Fix big bad boo-boo in the async scheduler (#999
<https://github.com/agronholm/apscheduler/issues/999>_; PR by @yourgithubaccount)`

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.