### PR TITLE
Fix "RuntimeError: cannot schedule new futures after interpreter shutdown"

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -8,6 +8,8 @@ APScheduler, see the :doc:`migration section <migration>`.
 
 - Fixed ``scheduler.shutdown()`` not raising ``SchedulerNotRunning`` (or raising the
   wrong exception) for asynchronous schedulers when the scheduler is in fact not running
+- Fixed "RuntimeError: cannot schedule new futures after interpreter shutdown" (#985
+<https://github.com/agronholm/apscheduler/issues/985>_; PR by @i-am-darshil)
 
 **3.11.0**
 

--- a/src/apscheduler/executors/pool.py
+++ b/src/apscheduler/executors/pool.py
@@ -6,6 +6,12 @@ from concurrent.futures.process import BrokenProcessPool
 from apscheduler.executors.base import BaseExecutor, run_job
 
 
+SHUTDOWN_MESSAGES = {
+    "cannot schedule new futures after shutdown",
+    "cannot schedule new futures after interpreter shutdown",
+}
+
+
 class BasePoolExecutor(BaseExecutor):
     @abstractmethod
     def __init__(self, pool):
@@ -24,10 +30,20 @@ class BasePoolExecutor(BaseExecutor):
             else:
                 self._run_job_success(job.id, f.result())
 
-        f = self._pool.submit(
-            run_job, job, job._jobstore_alias, run_times, self._logger.name
-        )
+        try:
+            f = self._pool.submit(
+                run_job, job, job._jobstore_alias, run_times, self._logger.name
+            )
+        except RuntimeError as e:
+            # There is a possible race condition between shutdown being invoked and the job being submitted to pool.
+            # This helps with not polluting logs with RuntimeError traces.
+            if str(e) in SHUTDOWN_MESSAGES:
+                self._logger.warning(f"Executor has been shut down, skipping job {job.id}: {e}")
+                return
+            else:
+                raise  # Re-raise unexpected RuntimeErrors
         f.add_done_callback(callback)
+
 
     def shutdown(self, wait=True):
         self._pool.shutdown(wait)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

Fixes #985

## Summary
This PR addresses a race condition where a job submission coincides with the executor shutting down, leading to unnecessary RuntimeError logs. While the error is harmless, it clutters logs and can be misleading.

### Root Cause
1. A job is scheduled and is about to be submitted to the executor’s thread/process pool.
2. Before submission completes, the executor begins shutting down.
3. The shutdown process acquires _shutdown_lock and marks the executor as shut down.
4. A job submission is attempted post-shutdown, causing a RuntimeError.
```
Traceback (most recent call last):
  File "C:\Users\gusta\teste\Em andamento\PyControlAPI\backend\nvenv\lib\site-packages\apscheduler\schedulers\base.py", line 988, in _process_jobs
    executor.submit_job(job, run_times)
  File "C:\Users\gusta\teste\Em andamento\PyControlAPI\backend\nvenv\lib\site-packages\apscheduler\executors\base.py", line 71, in submit_job
    self._do_submit_job(job, run_times)
  File "C:\Users\gusta\teste\Em andamento\PyControlAPI\backend\nvenv\lib\site-packages\apscheduler\executors\pool.py", line 28, in _do_submit_job
    f = self._pool.submit(run_job, job, job._jobstore_alias, run_times, self._logger.name)
  File "C:\Users\gusta\AppData\Local\Programs\Python\Python310\lib\concurrent\futures\thread.py", line 163, in submit
    raise RuntimeError('cannot schedule new futures after '
RuntimeError: cannot schedule new futures after interpreter shutdown
````

### Steps to reproduce
https://github.com/agronholm/apscheduler/issues/985#issuecomment-2642421776


## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ✅] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [ ✅] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue #999, the entry should look like this:

`* Fix big bad boo-boo in the async scheduler (#999
<https://github.com/agronholm/apscheduler/issues/999>_; PR by @yourgithubaccount)`

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
