### PR TITLE
Skip dispatching extend_acquired_job_leases with no jobs

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -64,8 +64,7 @@ APScheduler, see the :doc:`migration section <migration>`.
   schema if it's missing (PR by @zhu0629)
 - Fixed an issue with ``CronTrigger`` infinitely looping to get next date when DST ends
   (`#980 <https://github.com/agronholm/apscheduler/issues/980>`_; PR by @hlobit)
-- Skip dispatching extend_acquired_job_leases with no jobs (`#1031
-  <https://github.com/agronholm/apscheduler/issues/1031>`_; PR by @JacobHayes)
+- Skip dispatching extend_acquired_job_leases with no jobs (PR by @JacobHayes)
 
 **4.0.0a5**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -64,6 +64,8 @@ APScheduler, see the :doc:`migration section <migration>`.
   schema if it's missing (PR by @zhu0629)
 - Fixed an issue with ``CronTrigger`` infinitely looping to get next date when DST ends
   (`#980 <https://github.com/agronholm/apscheduler/issues/980>`_; PR by @hlobit)
+- Skip dispatching extend_acquired_job_leases with no jobs (`#1031
+  <https://github.com/agronholm/apscheduler/issues/1031>`_; PR by @JacobHayes)
 
 **4.0.0a5**
 

--- a/src/apscheduler/_schedulers/async_.py
+++ b/src/apscheduler/_schedulers/async_.py
@@ -1108,10 +1108,10 @@ class AsyncScheduler:
         async def extend_job_leases() -> None:
             while self._state is RunState.started:
                 await sleep(self.lease_duration.total_seconds() / 2)
-                job_ids = {job.id for job in self._running_jobs}
-                await self.data_store.extend_acquired_job_leases(
-                    self.identity, job_ids, self.lease_duration
-                )
+                if job_ids := {job.id for job in self._running_jobs}:
+                    await self.data_store.extend_acquired_job_leases(
+                        self.identity, job_ids, self.lease_duration
+                    )
 
         async with AsyncExitStack() as exit_stack:
             # Start the job executors


### PR DESCRIPTION
## Changes

After fixing https://github.com/agronholm/apscheduler/pull/1030, I noticed that we'd schedule the lease extension tasks even though there were no jobs to extend. This is a small "optimization" to skip creating those no-op tasks.

This isn't really visible without https://github.com/agronholm/apscheduler/pull/1030 since the `while` loop never hit without that fix, but GH doesn't support stacked PRs from forks so figured I'd push separately :shrug:.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue #999, the entry should look like this:

`* Fix big bad boo-boo in the async scheduler (#999
<https://github.com/agronholm/apscheduler/issues/999>_; PR by @yourgithubaccount)`

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
