### PR TITLE
Store `last_fire_time` on schedule release

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -65,6 +65,7 @@ APScheduler, see the :doc:`migration section <migration>`.
 - Fixed an issue with ``CronTrigger`` infinitely looping to get next date when DST ends
   (`#980 <https://github.com/agronholm/apscheduler/issues/980>`_; PR by @hlobit)
 - Skip dispatching extend_acquired_job_leases with no jobs (PR by @JacobHayes)
+- Added logic to store ``last_fire_time`` in datastore implementations (PR by @hlobit)
 
 **4.0.0a5**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -42,6 +42,8 @@ APScheduler, see the :doc:`migration section <migration>`.
 - **BREAKING** Changed the ``timezone`` argument to ``CronTrigger.from_crontab()`` into
   a keyword-only argument
 - **BREAKING** Added the ``metadata`` field to tasks, schedules and jobs
+- **BREAKING** Added logic to store ``last_fire_time`` in datastore implementations
+  (PR by @hlobit)
 - Added the ``start_time`` and ``end_time`` arguments to ``CronTrigger.from_crontab()``
   (`#676 <https://github.com/agronholm/apscheduler/issues/676>`_)
 - Added the ``psycopg`` event broker
@@ -65,7 +67,6 @@ APScheduler, see the :doc:`migration section <migration>`.
 - Fixed an issue with ``CronTrigger`` infinitely looping to get next date when DST ends
   (`#980 <https://github.com/agronholm/apscheduler/issues/980>`_; PR by @hlobit)
 - Skip dispatching extend_acquired_job_leases with no jobs (PR by @JacobHayes)
-- Added logic to store ``last_fire_time`` in datastore implementations (PR by @hlobit)
 
 **4.0.0a5**
 

--- a/src/apscheduler/datastores/memory.py
+++ b/src/apscheduler/datastores/memory.py
@@ -183,6 +183,7 @@ class MemoryDataStore(BaseDataStore):
             del self._schedules[index]
 
             # Re-add the schedule to its new position
+            schedule.last_fire_time = result.last_fire_time
             schedule.next_fire_time = result.next_fire_time
             schedule.acquired_by = None
             schedule.acquired_until = None

--- a/src/apscheduler/datastores/mongodb.py
+++ b/src/apscheduler/datastores/mongodb.py
@@ -207,7 +207,6 @@ class MongoDBDataStore(BaseExternalDataStore):
                 self._jobs_results.delete_many({}, session=session)
 
             self._schedules.create_index("task_id", session=session)
-            self._schedules.create_index("last_fire_time", session=session)
             self._schedules.create_index("next_fire_time", session=session)
             self._schedules.create_index("acquired_by", session=session)
             self._jobs.create_index("task_id", session=session)

--- a/src/apscheduler/datastores/mongodb.py
+++ b/src/apscheduler/datastores/mongodb.py
@@ -207,6 +207,7 @@ class MongoDBDataStore(BaseExternalDataStore):
                 self._jobs_results.delete_many({}, session=session)
 
             self._schedules.create_index("task_id", session=session)
+            self._schedules.create_index("last_fire_time", session=session)
             self._schedules.create_index("next_fire_time", session=session)
             self._schedules.create_index("acquired_by", session=session)
             self._jobs.create_index("task_id", session=session)
@@ -503,6 +504,7 @@ class MongoDBDataStore(BaseExternalDataStore):
                 },
                 "$set": {
                     "trigger": serialized_trigger,
+                    **marshal_timestamp(result.last_fire_time, "last_fire_time"),
                     **marshal_timestamp(result.next_fire_time, "next_fire_time"),
                 },
             }

--- a/src/apscheduler/datastores/sqlalchemy.py
+++ b/src/apscheduler/datastores/sqlalchemy.py
@@ -118,7 +118,8 @@ def marshal_timestamp(timestamp: datetime | None, key: str) -> Mapping[str, Any]
 
     return {
         key: int(timestamp.timestamp() * 1000_000),
-        key + "_utcoffset": cast(timedelta, timestamp.utcoffset()).total_seconds() // 60,
+        key + "_utcoffset": cast(timedelta, timestamp.utcoffset()).total_seconds()
+        // 60,
     }
 
 
@@ -554,9 +555,7 @@ class SQLAlchemyDataStore(BaseExternalDataStore):
         self, schedule: Schedule, conflict_policy: ConflictPolicy
     ) -> None:
         event: DataStoreEvent
-        values = self._convert_outgoing_fire_times(
-            schedule.marshal(self.serializer)
-        )
+        values = self._convert_outgoing_fire_times(schedule.marshal(self.serializer))
         insert = self._t_schedules.insert().values(**values)
         try:
             async for attempt in self._retry():
@@ -736,8 +735,12 @@ class SQLAlchemyDataStore(BaseExternalDataStore):
                                 {
                                     "p_id": result.schedule_id,
                                     "p_trigger": serialized_trigger,
-                                    **marshal_timestamp(result.last_fire_time, "p_last_fire_time"),
-                                    **marshal_timestamp(result.next_fire_time, "p_next_fire_time"),
+                                    **marshal_timestamp(
+                                        result.last_fire_time, "p_last_fire_time"
+                                    ),
+                                    **marshal_timestamp(
+                                        result.next_fire_time, "p_next_fire_time"
+                                    ),
                                 }
                             )
 

--- a/src/apscheduler/datastores/sqlalchemy.py
+++ b/src/apscheduler/datastores/sqlalchemy.py
@@ -297,7 +297,7 @@ class SQLAlchemyDataStore(BaseExternalDataStore):
         if self._supports_tzaware_timestamps:
             timestamp_type: TypeEngine[datetime] = DateTime(timezone=True)
             last_fire_time_tzoffset_columns: tuple[Column, ...] = (
-                Column("last_fire_time", timestamp_type, index=True),
+                Column("last_fire_time", timestamp_type),
             )
             next_fire_time_tzoffset_columns: tuple[Column, ...] = (
                 Column("next_fire_time", timestamp_type, index=True),
@@ -305,7 +305,7 @@ class SQLAlchemyDataStore(BaseExternalDataStore):
         else:
             timestamp_type = EmulatedTimestampTZ()
             last_fire_time_tzoffset_columns = (
-                Column("last_fire_time", BigInteger, index=True),
+                Column("last_fire_time", BigInteger),
                 Column("last_fire_time_utcoffset", SmallInteger),
             )
             next_fire_time_tzoffset_columns = (

--- a/src/apscheduler/datastores/sqlalchemy.py
+++ b/src/apscheduler/datastores/sqlalchemy.py
@@ -112,6 +112,16 @@ class EmulatedInterval(TypeDecorator[timedelta]):
         return timedelta(seconds=value / 1000000) if value is not None else None
 
 
+def marshal_timestamp(timestamp: datetime | None, key: str) -> Mapping[str, Any]:
+    if timestamp is None:
+        return {key: None, key + "_utcoffset": None}
+
+    return {
+        key: int(timestamp.timestamp() * 1000_000),
+        key + "_utcoffset": cast(timedelta, timestamp.utcoffset()).total_seconds() // 60,
+    }
+
+
 @attrs.define(eq=False, frozen=True)
 class _JobDiscard:
     job_id: UUID
@@ -257,37 +267,46 @@ class SQLAlchemyDataStore(BaseExternalDataStore):
 
         return InterfaceError, OSError
 
-    def _convert_incoming_next_fire_time(self, data: dict[str, Any]) -> dict[str, Any]:
-        if not self._supports_tzaware_timestamps:
-            utcoffset_minutes = data.pop("next_fire_time_utcoffset", None)
-            if utcoffset_minutes is not None:
-                tz = timezone(timedelta(minutes=utcoffset_minutes))
-                timestamp = data["next_fire_time"] / 1000_000
-                data["next_fire_time"] = datetime.fromtimestamp(timestamp, tz=tz)
+    def _convert_incoming_fire_times(self, data: dict[str, Any]) -> dict[str, Any]:
+        for field in ("last_fire_time", "next_fire_time"):
+            if not self._supports_tzaware_timestamps:
+                utcoffset_minutes = data.pop(f"{field}_utcoffset", None)
+                if utcoffset_minutes is not None:
+                    tz = timezone(timedelta(minutes=utcoffset_minutes))
+                    timestamp = data[field] / 1000_000
+                    data[field] = datetime.fromtimestamp(timestamp, tz=tz)
 
         return data
 
-    def _convert_outgoing_next_fire_time(self, data: dict[str, Any]) -> dict[str, Any]:
-        if not self._supports_tzaware_timestamps:
-            next_fire_time = data["next_fire_time"]
-            if next_fire_time is not None:
-                data["next_fire_time"] = int(next_fire_time.timestamp() * 1000_000)
-                data["next_fire_time_utcoffset"] = (
-                    next_fire_time.utcoffset().total_seconds() // 60
-                )
-            else:
-                data["next_fire_time_utcoffset"] = None
+    def _convert_outgoing_fire_times(self, data: dict[str, Any]) -> dict[str, Any]:
+        for field in ("last_fire_time", "next_fire_time"):
+            if not self._supports_tzaware_timestamps:
+                field_value = data[field]
+                if field_value is not None:
+                    data[field] = int(field_value.timestamp() * 1000_000)
+                    data[f"{field}_utcoffset"] = (
+                        field_value.utcoffset().total_seconds() // 60
+                    )
+                else:
+                    data[f"{field}_utcoffset"] = None
 
         return data
 
     def get_table_definitions(self) -> MetaData:
         if self._supports_tzaware_timestamps:
             timestamp_type: TypeEngine[datetime] = DateTime(timezone=True)
+            last_fire_time_tzoffset_columns: tuple[Column, ...] = (
+                Column("last_fire_time", timestamp_type, index=True),
+            )
             next_fire_time_tzoffset_columns: tuple[Column, ...] = (
                 Column("next_fire_time", timestamp_type, index=True),
             )
         else:
             timestamp_type = EmulatedTimestampTZ()
+            last_fire_time_tzoffset_columns = (
+                Column("last_fire_time", BigInteger, index=True),
+                Column("last_fire_time_utcoffset", SmallInteger),
+            )
             next_fire_time_tzoffset_columns = (
                 Column("next_fire_time", BigInteger, index=True),
                 Column("next_fire_time_utcoffset", SmallInteger),
@@ -333,8 +352,8 @@ class SQLAlchemyDataStore(BaseExternalDataStore):
             Column("job_executor", Unicode(500), nullable=False),
             Column("job_result_expiration_time", interval_type),
             Column("metadata", json_type, nullable=False),
+            *last_fire_time_tzoffset_columns,
             *next_fire_time_tzoffset_columns,
-            Column("last_fire_time", timestamp_type),
             Column("acquired_by", Unicode(500), index=True),
             Column("acquired_until", timestamp_type),
         )
@@ -438,7 +457,7 @@ class SQLAlchemyDataStore(BaseExternalDataStore):
                 schedules.append(
                     Schedule.unmarshal(
                         self.serializer,
-                        self._convert_incoming_next_fire_time(row._asdict()),
+                        self._convert_incoming_fire_times(row._asdict()),
                     )
                 )
             except SerializationError as exc:
@@ -535,7 +554,7 @@ class SQLAlchemyDataStore(BaseExternalDataStore):
         self, schedule: Schedule, conflict_policy: ConflictPolicy
     ) -> None:
         event: DataStoreEvent
-        values = self._convert_outgoing_next_fire_time(
+        values = self._convert_outgoing_fire_times(
             schedule.marshal(self.serializer)
         )
         insert = self._t_schedules.insert().values(**values)
@@ -708,29 +727,17 @@ class SQLAlchemyDataStore(BaseExternalDataStore):
                                 {
                                     "p_id": result.schedule_id,
                                     "p_trigger": serialized_trigger,
+                                    "p_last_fire_time": result.last_fire_time,
                                     "p_next_fire_time": result.next_fire_time,
                                 }
                             )
                         else:
-                            if result.next_fire_time is not None:
-                                timestamp: int | None = int(
-                                    result.next_fire_time.timestamp() * 1000_000
-                                )
-                                utcoffset = (
-                                    cast(
-                                        timedelta, result.next_fire_time.utcoffset()
-                                    ).total_seconds()
-                                    // 60
-                                )
-                            else:
-                                timestamp = utcoffset = None
-
                             update_args.append(
                                 {
                                     "p_id": result.schedule_id,
                                     "p_trigger": serialized_trigger,
-                                    "p_next_fire_time": timestamp,
-                                    "p_next_fire_time_utcoffset": utcoffset,
+                                    **marshal_timestamp(result.last_fire_time, "p_last_fire_time"),
+                                    **marshal_timestamp(result.next_fire_time, "p_next_fire_time"),
                                 }
                             )
 
@@ -739,8 +746,12 @@ class SQLAlchemyDataStore(BaseExternalDataStore):
                         extra_values: dict[str, BindParameter] = {}
                         p_id: BindParameter = bindparam("p_id")
                         p_trigger: BindParameter = bindparam("p_trigger")
+                        p_last_fire_time: BindParameter = bindparam("p_last_fire_time")
                         p_next_fire_time: BindParameter = bindparam("p_next_fire_time")
                         if not self._supports_tzaware_timestamps:
+                            extra_values["last_fire_time_utcoffset"] = bindparam(
+                                "p_last_fire_time_utcoffset"
+                            )
                             extra_values["next_fire_time_utcoffset"] = bindparam(
                                 "p_next_fire_time_utcoffset"
                             )
@@ -755,6 +766,7 @@ class SQLAlchemyDataStore(BaseExternalDataStore):
                             )
                             .values(
                                 trigger=p_trigger,
+                                last_fire_time=p_last_fire_time,
                                 next_fire_time=p_next_fire_time,
                                 acquired_by=None,
                                 acquired_until=None,

--- a/tests/test_datastores.py
+++ b/tests/test_datastores.py
@@ -281,9 +281,14 @@ async def test_acquire_release_schedules(
         assert len(schedules) == 3
         schedules.sort(key=lambda s: s.id)
         assert schedules[0].id == "s1"
+        assert schedules[0].last_fire_time == datetime(2020, 9, 14, tzinfo=timezone.utc)
         assert schedules[0].next_fire_time is None
         assert schedules[1].id == "s2"
+        assert schedules[1].last_fire_time == datetime(2020, 9, 14, tzinfo=timezone.utc)
+        assert schedules[1].next_fire_time == datetime(2020, 9, 15, tzinfo=timezone.utc)
         assert schedules[2].id == "s3"
+        assert schedules[2].last_fire_time is None
+        assert schedules[2].next_fire_time == datetime(2020, 9, 15, tzinfo=timezone.utc)
 
     # Check for the appropriate update and delete events
     received_event = events.pop(0)


### PR DESCRIPTION
I noticed that the value of `last_fire_time` (present in the `ScheduleResult`) is not stored in any of the available datastore implementations.

Here is an attempt to store the value.