### PR TITLE
Refactor example to use FastAPI lifespan instead of custom middleware

### DIFF
--- a/examples/web/asgi_fastapi.py
+++ b/examples/web/asgi_fastapi.py
@@ -11,14 +11,13 @@ basic web app at http://localhost:8000.
 
 from __future__ import annotations
 
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 from datetime import datetime
 
 from fastapi import FastAPI
-from fastapi.middleware import Middleware
-from fastapi.requests import Request
 from fastapi.responses import PlainTextResponse, Response
 from sqlalchemy.ext.asyncio import create_async_engine
-from starlette.types import ASGIApp, Receive, Scope, Send
 
 from apscheduler import AsyncScheduler
 from apscheduler.datastores.sqlalchemy import SQLAlchemyDataStore
@@ -30,35 +29,24 @@ def tick():
     print("Hello, the time is", datetime.now())
 
 
-class SchedulerMiddleware:
-    def __init__(
-        self,
-        app: ASGIApp,
-        scheduler: AsyncScheduler,
-    ) -> None:
-        self.app = app
-        self.scheduler = scheduler
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
+    engine = create_async_engine(
+        "postgresql+asyncpg://postgres:secret@localhost/testdb"
+    )
+    data_store = SQLAlchemyDataStore(engine)
+    event_broker = AsyncpgEventBroker.from_async_sqla_engine(engine)
+    scheduler = AsyncScheduler(data_store, event_broker)
 
-    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        if scope["type"] == "lifespan":
-            async with self.scheduler:
-                await self.scheduler.add_schedule(
-                    tick, IntervalTrigger(seconds=1), id="tick"
-                )
-                await self.scheduler.start_in_background()
-                await self.app(scope, receive, send)
-        else:
-            await self.app(scope, receive, send)
+    async with scheduler:
+        await scheduler.add_schedule(tick, IntervalTrigger(seconds=1), id="tick")
+        await scheduler.start_in_background()
+        yield
 
 
-async def root(request: Request) -> Response:
+async def root() -> Response:
     return PlainTextResponse("Hello, world!")
 
 
-engine = create_async_engine("postgresql+asyncpg://postgres:secret@localhost/testdb")
-data_store = SQLAlchemyDataStore(engine)
-event_broker = AsyncpgEventBroker.from_async_sqla_engine(engine)
-scheduler = AsyncScheduler(data_store, event_broker)
-middleware = [Middleware(SchedulerMiddleware, scheduler=scheduler)]
-app = FastAPI(middleware=middleware)
+app = FastAPI(lifespan=lifespan)
 app.add_api_route("/", root)


### PR DESCRIPTION
## Changes
This PR updates the example to use the FastAPI `lifespan` context manager instead of relying on the `scope` middleware pattern for startup and shutdown events. This approach is more idiomatic and easier to understand.

Specifically:

- Replaced the custom `SchedulerMiddleware` with a `lifespan` context.

- Moved scheduler setup into the lifespan handler.

- Cleaned up unnecessary middleware and request handling code.

Let me know if you'd like me to keep the old version as a separate example or add any additional explanation in comments or docs :)