### PR TITLE
[fix]]Add a argument `create_table` on class `SQLAlchemyJobStore`

### DIFF
--- a/docs/modules/jobstores/sqlalchemy.rst
+++ b/docs/modules/jobstores/sqlalchemy.rst
@@ -6,7 +6,7 @@
 API
 ---
 
-.. autoclass:: SQLAlchemyJobStore(url=None, engine=None, tablename='apscheduler_jobs', metadata=None, pickle_protocol=pickle.HIGHEST_PROTOCOL)
+.. autoclass:: SQLAlchemyJobStore(url=None, engine=None, tablename='apscheduler_jobs', metadata=None, pickle_protocol=pickle.HIGHEST_PROTOCOL, create_table=True)
     :show-inheritance:
 
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -8,6 +8,8 @@ APScheduler, see the :doc:`migration section <migration>`.
 
 - Fixed ``scheduler.shutdown()`` not raising ``SchedulerNotRunning`` (or raising the
   wrong exception) for asynchronous schedulers when the scheduler is in fact not running
+- Fixed ``SQLAlchemyJobStore`` not support the argument ``create_table``, raising the wrong excepotion
+  ``[apscheduler jobs] already exists`` in some db which not supposed ``if not exists``
 
 **3.11.0**
 

--- a/src/apscheduler/jobstores/sqlalchemy.py
+++ b/src/apscheduler/jobstores/sqlalchemy.py
@@ -46,6 +46,7 @@ class SQLAlchemyJobStore(BaseJobStore):
         should be
     :param dict engine_options: keyword arguments to :func:`~sqlalchemy.create_engine`
         (ignored if ``engine`` is given)
+    :param bool create_table: specify whether table should be created, defaults to true
     """
 
     def __init__(
@@ -57,6 +58,7 @@ class SQLAlchemyJobStore(BaseJobStore):
         pickle_protocol=pickle.HIGHEST_PROTOCOL,
         tableschema=None,
         engine_options=None,
+        create_table=True,
     ):
         super().__init__()
         self.pickle_protocol = pickle_protocol
@@ -79,10 +81,12 @@ class SQLAlchemyJobStore(BaseJobStore):
             Column("job_state", LargeBinary, nullable=False),
             schema=tableschema,
         )
+        self.create_table = create_table
 
     def start(self, scheduler, alias):
         super().start(scheduler, alias)
-        self.jobs_t.create(self.engine, True)
+        if self.create_table:
+            self.jobs_t.create(self.engine, True)
 
     def lookup_job(self, job_id):
         selectable = select(self.jobs_t.c.job_state).where(self.jobs_t.c.id == job_id)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes
Add a argument `create_table` on class `SQLAlchemyJobStore`

Fixes #. <!-- Provide issue number if exists -->

<!-- Please give a short brief about these changes. -->
I use a db which not supposed "if not exists",when i start the apscheduler job,it has an exception

sqlalchemy.exc.DatabaseError:(dmPython.DatabaseError) [CODE:-2124]Error in line: 9
Object [apscheduler jobs] already exists
[SQL:
CREATE TABLE apscheduler jobs(
id NVARCHAR2(191)NOT NULL,next run time FLOAT.
job state BLOB NOT NULL,
PRIMARY KEY (id)
)

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) added which would fail without your patch
- [√ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [√ ] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue #999, the entry should look like this:

`* Fix big bad boo-boo in the async scheduler (#999
<https://github.com/agronholm/apscheduler/issues/999>_; PR by @yourgithubaccount)`

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.