### PR TITLE
Add missing return statement in if_not_unset validator

### DIFF
--- a/src/apscheduler/_validators.py
+++ b/src/apscheduler/_validators.py
@@ -23,12 +23,14 @@ def aware_datetime(instance: Any, attribute: Attribute, value: Any) -> None:
         raise ValueError(f"{attribute.name} must be a timezone aware datetime")
 
 
-def if_not_unset(validator: Callable[[Any, Any, Any], None]) -> None:
+def if_not_unset(validator: Callable[[Any, Any, Any], None]) -> Callable:
     def validate(instance: Any, attribute: Any, value: Any) -> None:
         if value is unset:
             return
 
         validator(instance, attribute, value)
+
+    return validate
 
 
 def valid_metadata(instance: Any, attribute: Attribute, value: Any) -> None:


### PR DESCRIPTION
## Summary

`if_not_unset()` defines an inner `validate` function but never returns it, so all attrs fields using this validator have no validation at all.

## Problem

```python
def if_not_unset(validator: Callable[[Any, Any, Any], None]) -> None:
    def validate(instance: Any, attribute: Any, value: Any) -> None:
        if value is unset:
            return
        validator(instance, attribute, value)
    # missing: return validate
```

The function implicitly returns `None`, so attrs treats the field as having no validator. This affects `TaskDefaults.job_executor` and all `TaskParameters` fields — they accept any value without validation.

## Fix

Add `return validate` at the end of the function.
