### PR TITLE
Fix wrong variable references in valid_metadata validator

### DIFF
--- a/src/apscheduler/_validators.py
+++ b/src/apscheduler/_validators.py
@@ -33,7 +33,7 @@ def if_not_unset(validator: Callable[[Any, Any, Any], None]) -> None:
 
 def valid_metadata(instance: Any, attribute: Attribute, value: Any) -> None:
     def check_value(path: str, val: object) -> None:
-        if value is None:
+        if val is None:
             return
 
         if isinstance(val, list):
@@ -42,7 +42,7 @@ def valid_metadata(instance: Any, attribute: Attribute, value: Any) -> None:
         elif isinstance(val, dict):
             for k, v in val.items():
                 if not isinstance(k, str):
-                    raise ValueError(f"{path} has a non-string key ({key!r})")
+                    raise ValueError(f"{path} has a non-string key ({k!r})")
 
                 check_value(f"{path}[{k!r}]", v)
         elif not isinstance(val, (str, int, float, bool)):


### PR DESCRIPTION
## Summary

Two wrong variable references in the `valid_metadata` validator's inner `check_value` function.

## Bug 1: `value` instead of `val` in None check

```python
def check_value(path: str, val: object) -> None:
    if value is None:  # <-- should be `val`
        return
```

`value` refers to the outer metadata dict (always a dict, never None), so this check never triggers. As a result, `None` values inside metadata are incorrectly rejected as "not JSON compatible", even though `None` is a valid type per `MetadataType`.

```python
# This should be valid but raises ValueError
metadata = {"key": None}
```

## Bug 2: `key` instead of `k` in nested dict error message

```python
elif isinstance(val, dict):
    for k, v in val.items():
        if not isinstance(k, str):
            raise ValueError(f"{path} has a non-string key ({key!r})")  # <-- should be `k`
```

When a nested dict has a non-string key, the error message shows `key` from the *outer* `for key, val in value.items()` loop instead of `k` (the actual offending key in the nested dict).

## Fix

- `if value is None` → `if val is None`
- `({key!r})` → `({k!r})`
