### PR TITLE
Fix interval jobs stalling across DST spring-forward with ZoneInfo

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -4,6 +4,14 @@ Version history
 To find out how to migrate your application from a previous version of
 APScheduler, see the :doc:`migration section <migration>`.
 
+**UNRELEASED**
+
+- Fixed sub-minute interval jobs stalling for the duration of a DST spring-forward gap
+  when the scheduler was configured with a ``ZoneInfo`` time zone, caused by the wakeup
+  delay being computed from the naive wall-clock difference instead of the actual UTC
+  difference
+  (`#1103 <https://github.com/agronholm/apscheduler/issues/1103>`_)
+
 **3.11.2**
 
 - Fixed an issue where a job using a ``CronTrigger`` scheduled in a repeated time

--- a/src/apscheduler/schedulers/base.py
+++ b/src/apscheduler/schedulers/base.py
@@ -3,7 +3,7 @@ import warnings
 from abc import ABCMeta, abstractmethod
 from collections.abc import Mapping, MutableMapping
 from contextlib import ExitStack
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from importlib.metadata import entry_points
 from logging import getLogger
 from threading import TIMEOUT_MAX, RLock

--- a/src/apscheduler/schedulers/base.py
+++ b/src/apscheduler/schedulers/base.py
@@ -1252,22 +1252,8 @@ class BaseScheduler(metaclass=ABCMeta):
             self._logger.debug("No jobs; waiting until a job is added")
         else:
             now = datetime.now(self.timezone)
-            # Compute the delay from UTC instants. Subtracting two aware datetimes
-            # that share the same tzinfo object (here both carry ``self.timezone``)
-            # makes Python ignore the offsets and use the naive wall-clock
-            # difference. Across a DST spring-forward that yields ~3600 seconds
-            # instead of ~1, stalling the scheduler for the whole gap. ZoneInfo
-            # zones hit this; pytz dodges it by handing out a distinct fixed-offset
-            # tzinfo per instant.
             wait_seconds = min(
-                max(
-                    (
-                        next_wakeup_time.astimezone(timezone.utc)
-                        - now.astimezone(timezone.utc)
-                    ).total_seconds(),
-                    0,
-                ),
-                TIMEOUT_MAX,
+                max((next_wakeup_time.timestamp() - now.timestamp()), 0), TIMEOUT_MAX
             )
             self._logger.debug(
                 "Next wakeup is due at %s (in %f seconds)",

--- a/src/apscheduler/schedulers/base.py
+++ b/src/apscheduler/schedulers/base.py
@@ -3,7 +3,7 @@ import warnings
 from abc import ABCMeta, abstractmethod
 from collections.abc import Mapping, MutableMapping
 from contextlib import ExitStack
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from importlib.metadata import entry_points
 from logging import getLogger
 from threading import TIMEOUT_MAX, RLock
@@ -1252,8 +1252,22 @@ class BaseScheduler(metaclass=ABCMeta):
             self._logger.debug("No jobs; waiting until a job is added")
         else:
             now = datetime.now(self.timezone)
+            # Compute the delay from UTC instants. Subtracting two aware datetimes
+            # that share the same tzinfo object (here both carry ``self.timezone``)
+            # makes Python ignore the offsets and use the naive wall-clock
+            # difference. Across a DST spring-forward that yields ~3600 seconds
+            # instead of ~1, stalling the scheduler for the whole gap. ZoneInfo
+            # zones hit this; pytz dodges it by handing out a distinct fixed-offset
+            # tzinfo per instant.
             wait_seconds = min(
-                max((next_wakeup_time - now).total_seconds(), 0), TIMEOUT_MAX
+                max(
+                    (
+                        next_wakeup_time.astimezone(timezone.utc)
+                        - now.astimezone(timezone.utc)
+                    ).total_seconds(),
+                    0,
+                ),
+                TIMEOUT_MAX,
             )
             self._logger.debug(
                 "Next wakeup is due at %s (in %f seconds)",

--- a/tests/test_schedulers.py
+++ b/tests/test_schedulers.py
@@ -43,7 +43,7 @@ from apscheduler.schedulers import (
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.schedulers.base import STATE_RUNNING, STATE_STOPPED, BaseScheduler
 from apscheduler.triggers.base import BaseTrigger
-from apscheduler.util import undefined
+from apscheduler.util import localize, undefined
 
 
 class DummyScheduler(BaseScheduler):
@@ -1132,6 +1132,35 @@ class TestProcessJobs:
         }
 
         assert scheduler._process_jobs() == 5
+
+    def test_wait_time_across_dst_transition(self, scheduler, freeze_time, timezone):
+        """
+        Tests that the wait time is computed from absolute (UTC) instants across a
+        DST spring-forward transition.
+
+        Regression test for #1103: when the scheduler time zone is a ``ZoneInfo``
+        object, ``next_wakeup_time`` and ``now`` share the same ``tzinfo``
+        instance, so subtracting them used to ignore the UTC offsets and produce
+        the naive wall-clock difference. Across the spring-forward gap that
+        yielded a ~1 hour wait instead of ~1 second, stalling sub-minute interval
+        jobs for the entire DST gap.
+
+        """
+        # The DST transition must happen in the scheduler's own time zone, so pin
+        # it to the (parametrized) fixture zone rather than the host's local zone.
+        scheduler.timezone = timezone
+        # Europe/Berlin springs forward on 2026-03-29: 02:00 CET (+01:00) jumps to
+        # 03:00 CEST (+02:00). These two instants are one second apart in UTC.
+        now = localize(datetime(2026, 3, 29, 1, 59, 59), timezone)
+        next_run_time = localize(datetime(2026, 3, 29, 3, 0, 0), timezone)
+        freeze_time.set(now)
+        scheduler._jobstores = {
+            "default": MagicMock(
+                get_next_run_time=MagicMock(return_value=next_run_time)
+            )
+        }
+
+        assert scheduler._process_jobs() == 1
 
 
 class SchedulerImplementationTestBase:

--- a/tests/test_schedulers.py
+++ b/tests/test_schedulers.py
@@ -1146,20 +1146,12 @@ class TestProcessJobs:
         jobs for the entire DST gap.
 
         """
-        # The DST transition must happen in the scheduler's own time zone, so pin
-        # it to the (parametrized) fixture zone rather than the host's local zone.
-        scheduler.timezone = timezone
-        # Europe/Berlin springs forward on 2026-03-29: 02:00 CET (+01:00) jumps to
-        # 03:00 CEST (+02:00). These two instants are one second apart in UTC.
         now = localize(datetime(2026, 3, 29, 1, 59, 59), timezone)
         next_run_time = localize(datetime(2026, 3, 29, 3, 0, 0), timezone)
+        jobstore = MagicMock(BaseJobStore)
+        jobstore.get_next_run_time.configure_mock(return_value=next_run_time)
+        scheduler = DummyScheduler(jobstores={"default": jobstore}, timezone=timezone)
         freeze_time.set(now)
-        scheduler._jobstores = {
-            "default": MagicMock(
-                get_next_run_time=MagicMock(return_value=next_run_time)
-            )
-        }
-
         assert scheduler._process_jobs() == 1
 
 


### PR DESCRIPTION
Fixes #1103.

## Problem

When the scheduler is configured with a `ZoneInfo` time zone (as `tzlocal` 5.x returns from `get_localzone()`), sub-minute interval jobs stop firing for the entire duration of a DST spring-forward gap. During the US transition on 2026-03-08, jobs went silent for an hour and logged ~3600 "run time was missed" warnings.

## Root cause

`_process_jobs()` computes how long to sleep until the next run as:

```python
now = datetime.now(self.timezone)
wait_seconds = min(max((next_wakeup_time - now).total_seconds(), 0), TIMEOUT_MAX)
```

Both `next_wakeup_time` and `now` are aware datetimes whose tzinfo is `self.timezone` — the *same* object. Per the `datetime` docs, subtracting two aware datetimes that share the same `tzinfo` ignores the UTC offsets and uses the naive wall-clock difference. Across a spring-forward the offsets differ (e.g. `01:59:59+01:00` → `03:00:00+02:00`, only one second apart in UTC), so the naive difference comes out as ~3601 seconds instead of ~1. The scheduler then oversleeps and skips every fire time in the gap.

pytz time zones avoided this because pytz localizes each instant to a distinct fixed-offset tzinfo, so the subtraction is forced through UTC and stays correct. The trigger itself (`IntervalTrigger.get_next_fire_time` + `normalize`) already produces the right next fire time; only the wakeup-delay computation was wrong.

## Fix

Compute the delay from UTC instants (`next_wakeup_time.astimezone(timezone.utc) - now.astimezone(timezone.utc)`), so the elapsed time is correct for any `tzinfo` implementation. This mirrors the existing `datetime_utc_add()` helper, which already does DST-safe arithmetic in UTC.

## Testing

Added `test_wait_time_across_dst_transition`, modelled on the existing `test_wait_time`. It pins the scheduler's time zone to the parametrized fixture zone and asserts that a job due one second after the Europe/Berlin spring-forward yields a ~1 second wait. The test is parametrized over both the pytz and ZoneInfo back ends; it fails on `[zoneinfo]` without this fix (`3601.0 != 1`) and passes on both with it.

`python -m pytest tests/test_schedulers.py` — 212 passed. The full non-service unit suite (schedulers, util, job, expressions, triggers, executors) — 621 passed. Lint (`ruff check`) and format (`ruff format --check`) are clean on the changed files.