### PR TITLE
Fix numeric day_of_week range with step being ignored in CronTrigger

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -14,7 +14,8 @@ APScheduler, see the :doc:`migration section <migration>`.
 - Fixed an issue where ``CronTrigger.next()`` returned a non-existing date on a DST change
   (`#1059 <https://github.com/agronholm/apscheduler/issues/1059>`_; PR by @jonasitzmann)
 - Fixed a numeric ``day_of_week`` range with a step (e.g. ``"1-5/2"``) ignoring the step in
-  ``CronTrigger`` and matching every day in the range instead (PR by @Labib-Bin-Salam)
+  ``CronTrigger`` and matching every day in the range instead
+  (`#1117 <https://github.com/agronholm/apscheduler/pull/1117>`_; PR by @Labib-Bin-Salam)
 - Fixed jobs that were being run when the scheduler was gracefully stopped being left in
   an acquired state (`#946 <https://github.com/agronholm/apscheduler/issues/946>`_)
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -13,6 +13,8 @@ APScheduler, see the :doc:`migration section <migration>`.
   (`#1061 <https://github.com/agronholm/apscheduler/issues/1061>`_; PR by @jonasitzmann)
 - Fixed an issue where ``CronTrigger.next()`` returned a non-existing date on a DST change
   (`#1059 <https://github.com/agronholm/apscheduler/issues/1059>`_; PR by @jonasitzmann)
+- Fixed a numeric ``day_of_week`` range with a step (e.g. ``"1-5/2"``) ignoring the step in
+  ``CronTrigger`` and matching every day in the range instead (PR by @Labib-Bin-Salam)
 - Fixed jobs that were being run when the scheduler was gracefully stopped being left in
   an acquired state (`#946 <https://github.com/agronholm/apscheduler/issues/946>`_)
 

--- a/src/apscheduler/triggers/cron/fields.py
+++ b/src/apscheduler/triggers/cron/fields.py
@@ -138,6 +138,21 @@ class DayOfWeekField(BaseField, real=False, extra_compilers=(WeekdayRangeExpress
         match = RangeExpression.value_re.match(expr)
         if match:
             groups = match.groups()
+            # A step selects every nth weekday in the range, using cron's own
+            # numbering where both 0 and 7 mean Sunday. That numbering does not
+            # map linearly onto the internal, Monday-based numbering, so a
+            # stepped range cannot be rewritten as a single internal range;
+            # expand it into the individual weekdays it matches instead.
+            # Otherwise the step is silently dropped and the range ends up
+            # matching every one of its days.
+            if groups[2] and int(groups[0]) <= int(groups[1] or groups[0]):
+                first = int(groups[0])
+                last = int(groups[1] or groups[0])
+                step = int(groups[2])
+                for value in range(first, last + 1, step):
+                    super().append_expression(WEEKDAYS[(value - 1) % 7])
+                return
+
             first = int(groups[0]) - 1
             first = 6 if first < 0 else first
             if groups[1]:

--- a/tests/triggers/test_cron.py
+++ b/tests/triggers/test_cron.py
@@ -206,6 +206,33 @@ def test_weekday_range(timezone, serializer):
     )
 
 
+def test_weekday_numeric_range_with_step(timezone, serializer):
+    # A step in a numeric day_of_week range must be honored: "1-5/2" selects
+    # every second weekday in the Mon-Fri range (Mon, Wed, Fri), not all of
+    # them. Regression test for the step being silently dropped.
+    start_time = datetime(2020, 1, 1, tzinfo=timezone)
+    trigger = CronTrigger(
+        year=2020,
+        month=1,
+        week=2,
+        day_of_week="1-5/2",
+        start_time=start_time,
+        timezone=timezone,
+    )
+    if serializer:
+        trigger = serializer.deserialize(serializer.serialize(trigger))
+
+    assert trigger.next() == datetime(2020, 1, 6, tzinfo=timezone)  # Monday
+    assert trigger.next() == datetime(2020, 1, 8, tzinfo=timezone)  # Wednesday
+    assert trigger.next() == datetime(2020, 1, 10, tzinfo=timezone)  # Friday
+    assert trigger.next() is None
+    assert repr(trigger) == (
+        "CronTrigger(year='2020', month='1', day='*', week='2', "
+        "day_of_week='mon,wed,fri', hour='0', minute='0', second='0', "
+        "start_time='2020-01-01T00:00:00+01:00', timezone='Europe/Berlin')"
+    )
+
+
 def test_last_weekday(timezone, serializer):
     start_time = datetime(2020, 1, 1, tzinfo=timezone)
     trigger = CronTrigger(


### PR DESCRIPTION
## Changes

A numeric `day_of_week` range that has a step, such as `"1-5/2"`, silently dropped the step and matched **every** day in the range instead of every *n*th one. For example, `day_of_week="1-5/2"` fired on every weekday (Mon–Fri) rather than just Mon, Wed and Fri:

```python
from datetime import datetime, timezone
from apscheduler.triggers.cron import CronTrigger

t = CronTrigger(day_of_week="1-5/2", hour=0, timezone=timezone.utc,
                start_time=datetime(2024, 1, 1, tzinfo=timezone.utc))
print([t.next().strftime("%a") for _ in range(6)])
# before: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Mon']   <- step ignored
# after:  ['Mon', 'Wed', 'Fri', 'Mon', 'Wed', 'Fri']
```

APScheduler 3.x honored these steps (`DayOfWeekField("day_of_week", "1-5/2")` kept `1-5/2`), so this is a 4.x regression.

### Root cause

`DayOfWeekField.append_expression()` rewrites numeric weekday expressions into textual ones in order to remap cron's numbering (where both `0` and `7` mean Sunday) onto the internal, Monday-based numbering. That rewrite only carried the range endpoints and discarded the `/step`, and textual weekday ranges (`mon-fri`) have no step support to fall back on — so the step was lost and the range matched all of its days.

### Fix

Because cron's weekday numbering isn't linear in the internal numbering (e.g. `0-6/2` is `{sun, tue, thu, sat}` = internal `{6, 1, 3, 5}`), a stepped range can't be represented as a single internal range. So when a numeric range carries a step, expand it into the individual weekdays it matches. Non-stepped expressions and `*/step` are unchanged.

## Checklist

- [x] You've added tests (in `tests/`) which would fail without your patch
- [x] You've updated the documentation / changelog (in `docs/versionhistory.rst`)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`)

The new regression test `test_weekday_numeric_range_with_step` fails on `master` (fires Tue 2020-01-07 with `day_of_week='mon-fri'`) and passes with this change. `ruff`, `ruff format --check` and `mypy` are clean on the changed files.