### PR TITLE
Fix CBOR serializer incompatibility with cbor2 6.0+

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -17,7 +17,8 @@ APScheduler, see the :doc:`migration section <migration>`.
   an acquired state (`#946 <https://github.com/agronholm/apscheduler/issues/946>`_)
 - Fixed the CBOR serializer raising ``DeserializationError`` with cbor2 v6.0 and newer,
   caused by a change in the ``tag_hook`` signature and tag contents now being deserialized
-  as immutable objects (PR by @Labib-Bin-Salam)
+  as immutable objects
+  (`#1118 <https://github.com/agronholm/apscheduler/pull/1118>`_; PR by @Labib-Bin-Salam)
 
 **4.0.0a6**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -15,6 +15,9 @@ APScheduler, see the :doc:`migration section <migration>`.
   (`#1059 <https://github.com/agronholm/apscheduler/issues/1059>`_; PR by @jonasitzmann)
 - Fixed jobs that were being run when the scheduler was gracefully stopped being left in
   an acquired state (`#946 <https://github.com/agronholm/apscheduler/issues/946>`_)
+- Fixed the CBOR serializer raising ``DeserializationError`` with cbor2 v6.0 and newer,
+  caused by a change in the ``tag_hook`` signature and tag contents now being deserialized
+  as immutable objects (PR by @Labib-Bin-Salam)
 
 **4.0.0a6**
 

--- a/src/apscheduler/_converters.py
+++ b/src/apscheduler/_converters.py
@@ -77,7 +77,10 @@ def as_enum(enum_class: Any) -> Callable[[Any], Any]:
 
 def list_converter(converter: Callable[[Any], Any]) -> Callable[[Any], Any]:
     def convert(value: Any) -> Any:
-        if isinstance(value, list):
+        # Accept tuples too: the cbor2 >= 6 deserializer returns the contents of
+        # a tag as immutable objects, so a serialized list comes back as a tuple
+        # which must be coerced back to a (mutable) list.
+        if isinstance(value, (list, tuple)):
             return [converter(item) for item in value]
 
         return value

--- a/src/apscheduler/serializers/cbor.py
+++ b/src/apscheduler/serializers/cbor.py
@@ -5,7 +5,7 @@ from enum import Enum
 from typing import Any
 
 import attrs
-from cbor2 import CBORDecoder, CBOREncoder, CBOREncodeTypeError, CBORTag, dumps, loads
+from cbor2 import CBOREncoder, CBOREncodeTypeError, CBORTag, dumps, loads
 
 from .. import DeserializationError, SerializationError
 from .._marshalling import marshal_object, marshal_timezone, unmarshal_object
@@ -50,12 +50,16 @@ class CBORSerializer(Serializer):
                 f"cannot serialize type {value.__class__.__name__}"
             )
 
-    def _tag_hook(
-        self, decoder: CBORDecoder, tag: CBORTag, shareable_index: int | None = None
-    ) -> object:
+    def _tag_hook(self, *args: Any) -> object:
+        # cbor2 < 6 calls the tag hook as (decoder, tag, shareable_index=None),
+        # while cbor2 >= 6 calls it as (tag, immutable). Pick out the CBORTag so
+        # that deserialization works regardless of the installed cbor2 version.
+        tag = next(arg for arg in args if isinstance(arg, CBORTag))
         if tag.tag == self.type_tag:
             cls_ref, state = tag.value
             return unmarshal_object(cls_ref, state)
+
+        return tag
 
     def serialize(self, obj: object) -> bytes:
         try:

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -15,6 +15,8 @@ from apscheduler import (
     SerializationError,
 )
 from apscheduler.abc import Serializer
+from apscheduler.triggers.combining import OrTrigger
+from apscheduler.triggers.interval import IntervalTrigger
 
 
 @pytest.mark.parametrize(
@@ -46,6 +48,35 @@ def test_serialize_event(event: Event, serializer: Serializer) -> None:
     payload = serializer.serialize(event.marshal())
     deserialized = type(event).unmarshal(serializer.deserialize(payload))
     assert deserialized == event
+
+
+def test_serialize_trigger_with_mutable_list_state(serializer: Serializer) -> None:
+    # Regression test for cbor2 >= 6: a custom object is serialized as a tag and
+    # its contents are deserialized as immutable objects, so a list stored in the
+    # object's state comes back as a tuple. OrTrigger keeps a mutable list of the
+    # next fire times that must survive the round-trip and stay usable.
+    start_time = datetime(2020, 1, 1, tzinfo=timezone.utc)
+
+    def make_trigger() -> OrTrigger:
+        return OrTrigger(
+            triggers=[
+                IntervalTrigger(hours=1, start_time=start_time),
+                IntervalTrigger(hours=2, start_time=start_time),
+            ]
+        )
+
+    control = make_trigger()
+    trigger = make_trigger()
+
+    # Advance both once so the internal list of fire times is populated, then
+    # round-trip the trigger through the serializer.
+    assert trigger.next() == control.next()
+    trigger = serializer.deserialize(serializer.serialize(trigger))
+
+    # The restored trigger must keep producing the same fire times; this is what
+    # raised "'tuple' object does not support item assignment" under cbor2 >= 6.
+    for _ in range(3):
+        assert trigger.next() == control.next()
 
 
 def test_serialization_error(serializer: Serializer) -> None:


### PR DESCRIPTION
## Changes

The CBOR serializer is broken against **cbor2 >= 6.0** (current release): every `CBORSerializer.deserialize()` raises `DeserializationError`, which currently turns all CBOR-parametrized tests red.

```python
from datetime import datetime, timezone
from apscheduler.serializers.cbor import CBORSerializer
from apscheduler.triggers.date import DateTrigger

s = CBORSerializer()
t = DateTrigger(run_time=datetime(2020, 1, 1, tzinfo=timezone.utc))
s.deserialize(s.serialize(t))   # cbor2 6.x: apscheduler.DeserializationError
```

There are two root causes, both stemming from cbor2 6.0:

1. **`tag_hook` signature change.** cbor2 < 6 called the tag hook as `(decoder, tag, shareable_index=None)`; cbor2 >= 6 calls it as `(tag, immutable)`. So `_tag_hook` received the `CBORTag` in the wrong position and `tag.tag` evaluated on a `bool`, raising `'bool' object has no attribute 'tag'` → reported as `error decoding semantic tag 4664`. Fixed by locating the `CBORTag` among the arguments, so **both** calling conventions work (the `cbor2 >= 5.0` floor is kept). Also returns the tag unchanged for unrecognized tags (the documented cbor2 contract).

2. **Immutable tag contents.** cbor2 >= 6 deserializes the contents of a tag as immutable objects, so a `list` stored in an object's state comes back as a `tuple`. `OrTrigger`/`AndTrigger` keep a mutable list of next fire times and assign into it in `next()`, which raised `'tuple' object does not support item assignment` once deserialization got that far. Fixed by having `list_converter` coerce tuples back to lists (it is used only for that field).

## Verification

Locally with cbor2 6.1.2: the full `tests/triggers/` (164), `tests/test_serializers.py` (16) and `tests/test_marshalling.py` (14) suites pass; before this change every `[cbor]` parametrization in them failed. `ruff check`, `ruff format --check` and `mypy` are clean on the changed files.

Added a regression test (`test_serialize_trigger_with_mutable_list_state`) that round-trips an `OrTrigger` through the serializer and keeps using it — it covers both fixes and fails on `master` under `[cbor]`.

> Note: the remaining red jobs in CI are the pre-existing `test_datastores.py [asyncpg]`/`[mongodb]` **errors** (external services unavailable in the run) — they use the pickle serializer, are unrelated to CBOR, and are already failing on `master`.

## Checklist

- [x] You've added tests (in `tests/`) which would fail without your patch
- [x] You've updated the documentation / changelog (in `docs/versionhistory.rst`)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`)