### PR TITLE
Fix scheduler crash when a job is rerun after its lease expired

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -15,6 +15,12 @@ APScheduler, see the :doc:`migration section <migration>`.
   (`#1059 <https://github.com/agronholm/apscheduler/issues/1059>`_; PR by @jonasitzmann)
 - Fixed jobs that were being run when the scheduler was gracefully stopped being left in
   an acquired state (`#946 <https://github.com/agronholm/apscheduler/issues/946>`_)
+- Fixed the scheduler crashing with ``KeyError`` when a job's lease expired while the
+  job was still running and the job was then acquired (and run) a second time: the
+  scheduler now skips acquired jobs that are still running in it, and releasing an
+  already-released job is a no-op in ``MemoryDataStore`` (as it already was in the
+  external data stores), no longer corrupting the task's running jobs counter
+  (`#1116 <https://github.com/agronholm/apscheduler/issues/1116>`_; PR by @leobaray)
 
 **4.0.0a6**
 

--- a/src/apscheduler/_schedulers/async_.py
+++ b/src/apscheduler/_schedulers/async_.py
@@ -1158,6 +1158,20 @@ class AsyncScheduler:
                         self.identity, self.lease_duration, limit
                     )
                     for job in jobs:
+                        # A job can be reacquired while still running in this
+                        # scheduler if its lease expired in the meantime (e.g. the
+                        # lease renewal task was starved by a saturated event
+                        # loop). Running a second copy would make the duplicate
+                        # release crash the scheduler (#1116).
+                        if job in self._running_jobs:
+                            self.logger.warning(
+                                "Skipping job %s: it was reacquired after its "
+                                "lease expired, but is still running in this "
+                                "scheduler",
+                                job.id,
+                            )
+                            continue
+
                         task = await self.data_store.get_task(job.task_id)
                         func = self._get_task_callable(task)
                         self._running_jobs.add(job)
@@ -1230,4 +1244,7 @@ class AsyncScheduler:
             finally:
                 current_job.reset(token)
         finally:
-            self._running_jobs.remove(job)
+            # discard() instead of remove(): if the job's lease expired mid-run and
+            # it was run a second time, the earlier finisher already removed the
+            # (id-equal) entry, and remove() would crash the scheduler (#1116)
+            self._running_jobs.discard(job)

--- a/src/apscheduler/datastores/memory.py
+++ b/src/apscheduler/datastores/memory.py
@@ -288,6 +288,17 @@ class MemoryDataStore(BaseDataStore):
         return jobs
 
     async def release_job(self, scheduler_id: str, job: Job, result: JobResult) -> None:
+        # Delete the job. If it's already gone, it was released before: its lease
+        # expired while it was still running and the job was acquired (and released)
+        # again. The redundant release must then be a no-op, like the idempotent
+        # DELETE in the external data stores — in particular, the task's running
+        # jobs counter must not be decremented a second time (#1116).
+        stored_job = self._jobs_by_id.pop(result.job_id, None)
+        if stored_job is None:
+            return
+
+        job = stored_job
+
         # Record the job result
         if result.expires_at > result.finished_at:
             self._job_results[result.job_id] = result
@@ -295,9 +306,6 @@ class MemoryDataStore(BaseDataStore):
         # Decrement the number of running jobs for this task
         if job.acquired_by:
             self._tasks[job.task_id].running_jobs -= 1
-
-        # Delete the job
-        job = self._jobs_by_id.pop(result.job_id)
 
         # Remove the job from the jobs belonging to its task
         task_jobs = self._jobs_by_task_id[job.task_id]

--- a/tests/test_datastores.py
+++ b/tests/test_datastores.py
@@ -601,6 +601,54 @@ async def test_acquire_jobs_lock_timeout(
     assert acquired[0].id == job.id
 
 
+async def test_release_job_after_lease_expired(
+    datastore: DataStore, time_machine: TimeMachineFixture
+) -> None:
+    """
+    Test that when a job is acquired again because the original scheduler's lease
+    expired while the job was still running, the belated release from the original
+    scheduler is a no-op instead of an error, and does not decrement the task's
+    running jobs counter a second time (#1116).
+
+    """
+    await datastore.add_task(
+        Task(id="task1", func="contextlib:asynccontextmanager", job_executor="async")
+    )
+    # the default result_expiration_time of 0 keeps both releases from recording a
+    # result; this test is about the release of the job itself
+    job = Job(task_id="task1", executor="async")
+    await datastore.add_job(job)
+
+    # The first scheduler acquires the job, but doesn't finish within the lease
+    time_machine.move_to(datetime.now(timezone.utc), tick=False)
+    acquired1 = await datastore.acquire_jobs("worker1", timedelta(seconds=30), 1)
+    assert len(acquired1) == 1
+    assert acquired1[0].id == job.id
+
+    # After the lease expires, a second scheduler acquires the job
+    time_machine.shift(31)
+    acquired2 = await datastore.acquire_jobs("worker2", timedelta(seconds=30), 1)
+    assert len(acquired2) == 1
+    assert acquired2[0].id == job.id
+
+    # The second scheduler finishes the job and releases it
+    await datastore.release_job(
+        "worker2",
+        acquired2[0],
+        JobResult.from_job(acquired2[0], JobOutcome.success),
+    )
+
+    # The belated release from the first scheduler must be a no-op
+    await datastore.release_job(
+        "worker1",
+        acquired1[0],
+        JobResult.from_job(acquired1[0], JobOutcome.success),
+    )
+
+    # The task's running jobs counter must not have gone negative
+    assert (await datastore.get_task("task1")).running_jobs == 0
+
+
 async def test_acquire_jobs_max_number_exceeded(datastore: DataStore) -> None:
     await datastore.add_task(
         Task(


### PR DESCRIPTION
## Changes

Fixes #1116.

When a job's lease expires while the job is still running (reachable in normal
operation: the lease renewal task is just another coroutine, so a saturated
event loop can starve it), `acquire_jobs()` hands the same job out again and the
scheduler runs a second copy. Since `Job` hashes/compares by `id`, the second
copy deduplicates into the single `_running_jobs` entry, and whichever run
finishes last crashes the scheduler with `KeyError` in two places
(`MemoryDataStore.release_job()` and `AsyncScheduler._run_job()`). The redundant
release also decremented the task's `running_jobs` counter a second time,
silently corrupting the slot accounting.

This PR takes both directions discussed in the issue, since they guard
different layers:

- **`AsyncScheduler`**: acquired jobs that are still running in this scheduler
  are skipped (with a warning) instead of being run a second time, so a lease
  expiry can no longer start a duplicate run in-process. Cross-scheduler
  duplicates remain possible by design (that's what leases are for), which is
  why the defensive fixes below still matter.
- **`AsyncScheduler._run_job()`**: unregisters the job with `discard()` instead
  of `remove()`, tolerating a duplicate run that was already unregistered.
- **`MemoryDataStore.release_job()`**: releasing an already-released job is now
  a no-op — like the idempotent `DELETE` the external data stores already do —
  and in particular no longer decrements the task's running jobs counter a
  second time.

The new test (`test_release_job_after_lease_expired`) exercises the
lease-expiry/steal/double-release sequence through the public data store API
and fails on the unpatched `MemoryDataStore` with the exact `KeyError` from the
issue. I ran it against the memory, sqlite and MySQL stores locally (the
PostgreSQL/MongoDB fixtures aren't runnable on my machine — ports taken by
local services); the issue's reproduction script now runs past the lease expiry
with the new warning logged instead of crashing.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features) — not applicable (bugfix; no documented behavior change)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).
