### PR TITLE
Preserve the callable when configuring a task from a Task object (#1001)

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -15,6 +15,9 @@ APScheduler, see the :doc:`migration section <migration>`.
   (`#1059 <https://github.com/agronholm/apscheduler/issues/1059>`_; PR by @jonasitzmann)
 - Fixed jobs that were being run when the scheduler was gracefully stopped being left in
   an acquired state (`#946 <https://github.com/agronholm/apscheduler/issues/946>`_)
+- Fixed ``configure_task()`` dropping the callable reference when passed a ``Task``
+  object, causing the configured task to be stored with ``func=None``
+  (`#1001 <https://github.com/agronholm/apscheduler/issues/1001>`_)
 
 **4.0.0a6**
 

--- a/src/apscheduler/_schedulers/async_.py
+++ b/src/apscheduler/_schedulers/async_.py
@@ -358,6 +358,10 @@ class AsyncScheduler:
             if func is unset:
                 func = func_or_task_id
         elif isinstance(func_or_task_id, Task):
+            # Carry over the callable reference stored on the task, otherwise the
+            # configured task would end up with func=None and the scheduler would
+            # fail to look up the callable when the job runs (#1001).
+            func_ref = func_or_task_id.func
             task_params = TaskParameters(
                 id=func_or_task_id.id,
                 job_executor=func_or_task_id.job_executor,

--- a/tests/test_schedulers.py
+++ b/tests/test_schedulers.py
@@ -47,6 +47,7 @@ from apscheduler import (
     SchedulerStarted,
     SchedulerStopped,
     ScheduleUpdated,
+    Task,
     TaskAdded,
     TaskDefaults,
     TaskUpdated,
@@ -211,6 +212,24 @@ class TestAsyncScheduler:
                 event = await receive.receive()
                 assert isinstance(event, TaskUpdated)
                 assert event.task_id == "mytask"
+
+    async def test_configure_task_from_task_object(self) -> None:
+        # Passing a Task object must preserve its callable reference; otherwise
+        # the task is stored with func=None and jobs fail to look up the
+        # callable when they run (#1001).
+        async with AsyncScheduler() as scheduler:
+            await scheduler.configure_task(
+                Task(
+                    id="mytask",
+                    func=f"{__name__}:dummy_async_job",
+                    job_executor="async",
+                )
+            )
+            tasks = await scheduler.get_tasks()
+            assert len(tasks) == 1
+            assert tasks[0].id == "mytask"
+            assert tasks[0].func == f"{__name__}:dummy_async_job"
+            assert tasks[0].job_executor == "async"
 
     async def test_configure_task_with_decorator(self) -> None:
         async with AsyncScheduler() as scheduler:


### PR DESCRIPTION
## Summary

Closes #1001.

`AsyncScheduler.configure_task()` accepts a callable, a task ID or a `Task` object. When passed a `Task`, it stored the task with `func=None`, so a later `add_job()` for that task crashed the scheduler with a callable lookup error:

```python
the_task = Task(id="test", func="__main__:my_func", job_executor="threadpool")
await scheduler.configure_task(the_task)
await scheduler.get_tasks()
# [Task(id='test', func=None, ...)]   <-- func was dropped
```

## Root cause

The `Task` branch of `configure_task()` built `TaskParameters` from the task's `id`, `job_executor`, `max_running_jobs`, `misfire_grace_time` and `metadata`, but never read `func_or_task_id.func`. The callable branch sets `func`, and the string branch reloads the stored task, but the `Task` branch left `func_ref` at its initial `None`, which is then used to build the task.

## Fix

Copy the task's callable reference into `func_ref` in the `Task` branch. Since `Task.func` is already a `"module:function"` reference string, it flows straight through to the created task. An explicitly passed `func=` keyword argument still takes precedence (it overrides `func_ref` via `callable_to_ref` further down), so no other behavior changes.

## Tests

Added `test_configure_task_from_task_object`, which configures a task from a `Task` object and asserts the stored `func` (and `job_executor`) are preserved. It fails on `master` (`func=None`) and passes with this change. `ruff check`/`ruff format` are clean; added a changelog entry under **UNRELEASED**.