### PR TITLE
Fix step being dropped from named cron month ranges

### DIFF
--- a/src/apscheduler/triggers/cron/expressions.py
+++ b/src/apscheduler/triggers/cron/expressions.py
@@ -151,10 +151,10 @@ class RangeExpression(AllExpression):
 
 class MonthRangeExpression(RangeExpression):
     value_re: ClassVar[Pattern] = re.compile(
-        r"(?P<first>[a-z]+)(?:-(?P<last>[a-z]+))?", re.IGNORECASE
+        r"(?P<first>[a-z]+)(?:-(?P<last>[a-z]+))?(?:/(?P<step>\d+))?$", re.IGNORECASE
     )
 
-    def __init__(self, first: str, last: str | None = None):
+    def __init__(self, first: str, last: str | None = None, step: str | None = None):
         try:
             first_num = MONTHS.index(first.lower()) + 1
         except ValueError:
@@ -168,13 +168,18 @@ class MonthRangeExpression(RangeExpression):
         else:
             last_num = None
 
-        super().__init__(first=first_num, last=last_num)
+        super().__init__(first=first_num, last=last_num, step=step)
 
     def __str__(self) -> str:
         if self.last != self.first and self.last is not None:
-            return f"{MONTHS[self.first - 1]}-{MONTHS[self.last - 1]}"
+            rangeval = f"{MONTHS[self.first - 1]}-{MONTHS[self.last - 1]}"
+        else:
+            rangeval = MONTHS[self.first - 1]
 
-        return MONTHS[self.first - 1]
+        if self.step:
+            return f"{rangeval}/{self.step}"
+
+        return rangeval
 
 
 @attrs.define(kw_only=True, init=False)

--- a/tests/triggers/test_cron.py
+++ b/tests/triggers/test_cron.py
@@ -103,6 +103,22 @@ def test_cron_trigger_1(timezone, serializer):
     )
 
 
+def test_month_named_range_step(timezone):
+    # A step on a named month range must be honored, exactly like the numeric
+    # form ("1-12/3"); it used to be silently dropped, so the schedule fired
+    # every month instead of quarterly.
+    start_time = datetime(2024, 1, 1, tzinfo=timezone)
+    trigger = CronTrigger(
+        month="jan-dec/3", day=1, start_time=start_time, timezone=timezone
+    )
+    assert trigger.next() == datetime(2024, 1, 1, tzinfo=timezone)
+    assert trigger.next() == datetime(2024, 4, 1, tzinfo=timezone)
+    assert trigger.next() == datetime(2024, 7, 1, tzinfo=timezone)
+    assert trigger.next() == datetime(2024, 10, 1, tzinfo=timezone)
+    assert trigger.next() == datetime(2025, 1, 1, tzinfo=timezone)
+    assert "month='jan-dec/3'" in repr(trigger)
+
+
 def test_cron_trigger_2(timezone, serializer):
     start_time = datetime(2009, 10, 14, tzinfo=timezone)
     trigger = CronTrigger(


### PR DESCRIPTION
### The bug

A `/step` on a **named** month range is silently dropped, so the schedule fires every month instead of on the stepped interval:

```python
CronTrigger(month="jan-dec/3", day=1)   # fires every month  <- BUG
CronTrigger(month="1-12/3",   day=1)     # fires quarterly    (correct)
```

`CronTrigger.from_crontab("0 0 1 jan-dec/3 *")` misfires the same way. The numeric form of the identical schedule is handled correctly, so APScheduler's own numeric path is the oracle — `jan-dec/3` and `1-12/3` are the same set {Jan, Apr, Jul, Oct}. `repr()` confirmed the step was gone (`month='jan-dec'`).

### Root cause

`src/apscheduler/triggers/cron/expressions.py`, `MonthRangeExpression`:

```python
value_re = re.compile(r"(?P<first>[a-z]+)(?:-(?P<last>[a-z]+))?", re.IGNORECASE)
def __init__(self, first, last=None): ...  # no step
```

It has no `(?:/(?P<step>\d+))?` group and no `$` end-anchor (the numeric `RangeExpression.value_re` has both). Since `BaseField.append_expression` uses `value_re.match()` (not `fullmatch`), the trailing `/3` matches nothing and is silently dropped, so the expression compiles as a plain range.

### The fix

Add the step group + `$` anchor to the regex, thread `step` through `__init__` into `RangeExpression` (which already validates and honors it), and include it in `__str__`:

- `month="jan-dec/3"` now fires quarterly (matching `1-12/3`); `feb-oct/2` fires bi-monthly; an over-large step (`jan-mar/12`) is now rejected, like the numeric path.
- The `$` anchor turns previously-silently-truncated input into a proper "Unrecognized expression" error.

### Verification

- Added `test_month_named_range_step` asserting the named form fires quarterly and `repr` shows the step. It fails on `master` (fires 2024-02 instead of 2024-04) and passes with the fix.
- `tests/triggers/test_cron.py`: 73 passed (was 72 + the new test). The 39 pre-existing failures are all cbor2-serialization version noise, unrelated to trigger logic and identical with/without this change.

### Relationship to #1117

Open PR #1117 fixes the **numeric `day_of_week`** step-drop in `triggers/cron/fields.py` (`DayOfWeekField.append_expression`). This PR is a different instance of the same class of bug, in a different file (`expressions.py`, `MonthRangeExpression`), and the two don't overlap — #1117 does not touch the month path. Named `day_of_week` ranges (`mon-fri/2`) have the same issue via `WeekdayRangeExpression` plus the `DayOfWeekField` textual conversion/wraparound-split; I left that out to keep this change focused on the month case — happy to extend or consolidate however you prefer.

---

This PR was authored by an AI coding agent (Claude Code) running on this account: the AI found the bug, ran the repro, wrote the test, and wrote this description. The human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.
