### PR TITLE
Clarify numeric `day_of_week` cron convention in `CronTrigger`

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -15,6 +15,10 @@ APScheduler, see the :doc:`migration section <migration>`.
   (`#1059 <https://github.com/agronholm/apscheduler/issues/1059>`_; PR by @jonasitzmann)
 - Fixed jobs that were being run when the scheduler was gracefully stopped being left in
   an acquired state (`#946 <https://github.com/agronholm/apscheduler/issues/946>`_)
+- Clarified in the ``CronTrigger`` documentation that numeric ``day_of_week`` values
+  follow the standard cron convention (``0`` and ``7`` are Sunday), as opposed to the
+  Monday-based ordering used by weekday names
+  (`#931 <https://github.com/agronholm/apscheduler/issues/931>`_)
 
 **4.0.0a6**
 

--- a/src/apscheduler/triggers/cron/__init__.py
+++ b/src/apscheduler/triggers/cron/__init__.py
@@ -29,10 +29,11 @@ class CronTrigger(Trigger):
 
     :param year: 4-digit year
     :param month: month (1-12)
-    :param day: day of the (1-31)
+    :param day: day of the month (1-31)
     :param week: ISO week (1-53)
-    :param day_of_week: number or name of weekday (0-7 or sun,mon,tue,wed,thu,fri,sat,
-        sun)
+    :param day_of_week: number or name of weekday (0-7 or mon,tue,wed,thu,fri,sat,sun);
+        numeric values follow the standard cron convention where both ``0`` and ``7``
+        mean Sunday, ``1`` means Monday and ``6`` means Saturday
     :param hour: hour (0-23)
     :param minute: minute (0-59)
     :param second: second (0-59)
@@ -42,7 +43,11 @@ class CronTrigger(Trigger):
     :param timezone: time zone to use for the date/time calculations
         (defaults to the local timezone)
 
-    .. note:: The first weekday is always **monday**.
+    .. note:: Numeric ``day_of_week`` values follow the standard cron convention, in
+        which ``0`` and ``7`` both mean Sunday, ``1`` means Monday and so on up to ``6``
+        for Saturday. Weekday **names** and name ranges (such as ``mon-fri``) instead use
+        an ordering that starts on Monday, so a wrapping range like ``sat-tue`` covers
+        Saturday, Sunday, Monday and Tuesday.
     """
 
     FIELDS_MAP: ClassVar[list[tuple[str, type[BaseField]]]] = [

--- a/tests/triggers/test_cron.py
+++ b/tests/triggers/test_cron.py
@@ -41,6 +41,31 @@ def test_invalid_weekday_position_name():
 
 
 @pytest.mark.parametrize(
+    "number, name",
+    [
+        (0, "sun"),
+        (1, "mon"),
+        (2, "tue"),
+        (3, "wed"),
+        (4, "thu"),
+        (5, "fri"),
+        (6, "sat"),
+        (7, "sun"),
+    ],
+)
+def test_numeric_day_of_week_follows_cron_convention(number, name):
+    """
+    Numeric ``day_of_week`` values must use the standard cron convention where both
+    ``0`` and ``7`` mean Sunday, ``1`` means Monday and ``6`` means Saturday.
+    """
+    start_time = datetime(2024, 1, 1, tzinfo=ZoneInfo("UTC"))
+    numeric_trigger = CronTrigger(day_of_week=number, start_time=start_time)
+    named_trigger = CronTrigger(day_of_week=name, start_time=start_time)
+    assert f"day_of_week='{name}'" in repr(numeric_trigger)
+    assert repr(numeric_trigger) == repr(named_trigger)
+
+
+@pytest.mark.parametrize(
     "values, expected",
     [
         (


### PR DESCRIPTION
## Changes

Fixes #931.

The `CronTrigger` docstring only stated that "the first weekday is always monday",
which conflicts with how numeric `day_of_week` input is actually interpreted on the
4.x branch: numbers follow the standard cron convention, where `0` and `7` both mean
Sunday, `1` means Monday and `6` means Saturday (the Monday-based ordering applies to
weekday *names* and name ranges, not to numeric values). Since `docs/api.rst`
autodocuments this class, the ambiguity is live in the published API reference — which
is exactly the confusion reported in #931.

This PR:
- Rewrites the `day_of_week` parameter description and the accompanying note to
  distinguish the numeric cron convention from the name-based (Monday-first) ordering,
  with a wrapping-range example.
- Fixes a small typo in the `day` parameter description ("day of the" -> "day of the
  month").
- Adds a parametrized regression test that pins the numeric-to-weekday mapping (0-7),
  so the documented cron convention can't be broken silently by future refactors.

## Checklist

- [x] Tests added (`tests/triggers/test_cron.py::test_numeric_day_of_week_follows_cron_convention`)
- [x] Documentation updated (`CronTrigger` docstring, which renders into `docs/api.rst`)
- [x] Changelog entry added (`docs/versionhistory.rst`, UNRELEASED)
