### PR TITLE
Release schedules with expired leases during clean-up

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -19,6 +19,10 @@ APScheduler, see the :doc:`migration section <migration>`.
 - Fixed the documented ``psycopg`` extra not being declared in the project metadata, so
   ``pip install apscheduler[psycopg]`` silently installed nothing for the Psycopg event
   broker (`#1133 <https://github.com/agronholm/apscheduler/issues/1133>`_)
+- Fixed schedules staying stuck when the scheduler holding them died without releasing
+  them; clean-up now releases schedules whose leases have expired and wakes up the
+  other schedulers so they can acquire them
+  (`#1053 <https://github.com/agronholm/apscheduler/issues/1053>`_)
 
 **4.0.0a6**
 

--- a/src/apscheduler/abc.py
+++ b/src/apscheduler/abc.py
@@ -402,6 +402,8 @@ class DataStore(metaclass=ABCMeta):
         * Purge expired job results (where ``expires_at`` is less or equal to the
           current time)
         * Release jobs with expired leases with the ``cancelled`` outcome
+        * Release schedules with expired leases, publishing a
+          :class:`~apscheduler.ScheduleUpdated` event for each of them
         * Purge finished schedules (where ``next_run_time`` is ``None``) that have no
           running jobs associated with them
         """

--- a/src/apscheduler/datastores/memory.py
+++ b/src/apscheduler/datastores/memory.py
@@ -376,6 +376,18 @@ class MemoryDataStore(BaseDataStore):
             assert job.acquired_by is not None
             await self.release_job(job.acquired_by, job, result)
 
+        # Release any schedules whose leases have expired
+        for schedule in self._schedules:
+            if schedule.acquired_until is not None and schedule.acquired_until < now:
+                schedule.acquired_by = None
+                schedule.acquired_until = None
+                event = ScheduleUpdated(
+                    schedule_id=schedule.id,
+                    task_id=schedule.task_id,
+                    next_fire_time=schedule.next_fire_time,
+                )
+                await self._event_broker.publish(event)
+
         # Clean up finished schedules that have no running jobs
         finished_schedule_ids = [
             schedule_id

--- a/src/apscheduler/datastores/mongodb.py
+++ b/src/apscheduler/datastores/mongodb.py
@@ -836,7 +836,7 @@ class MongoDBDataStore(BaseExternalDataStore):
                 await self._event_broker.publish(event)
 
     async def cleanup(self) -> None:
-        events: list[JobReleased | ScheduleRemoved] = []
+        events: list[JobReleased | ScheduleRemoved | ScheduleUpdated] = []
         async for attempt in self._retry():
             with attempt:
                 async with self._client.start_session() as session:
@@ -897,6 +897,42 @@ class MongoDBDataStore(BaseExternalDataStore):
                                     doc["scheduled_fire_time"],
                                 )
                             )
+
+                    # Release any schedules whose leases have expired
+                    expired_schedule_ids: list[str] = []
+                    async with self._schedules.find(
+                        {"acquired_until": {"$lt": now.timestamp()}},
+                        projection=[
+                            "_id",
+                            "task_id",
+                            "next_fire_time",
+                            "next_fire_time_utcoffset",
+                        ],
+                        session=session,
+                    ) as cursor:
+                        async for doc in cursor:
+                            unmarshal_timestamps(doc)
+                            expired_schedule_ids.append(doc["_id"])
+                            events.append(
+                                ScheduleUpdated(
+                                    schedule_id=doc["_id"],
+                                    task_id=doc["task_id"],
+                                    next_fire_time=doc["next_fire_time"],
+                                )
+                            )
+
+                    if expired_schedule_ids:
+                        await self._schedules.update_many(
+                            {"_id": {"$in": expired_schedule_ids}},
+                            {
+                                "$unset": {
+                                    "acquired_by": True,
+                                    "acquired_until": True,
+                                    "acquired_until_utcoffset": True,
+                                }
+                            },
+                            session=session,
+                        )
 
                     # Delete finished schedules that not having any associated jobs
                     if finished_schedules:

--- a/src/apscheduler/datastores/sqlalchemy.py
+++ b/src/apscheduler/datastores/sqlalchemy.py
@@ -1207,6 +1207,39 @@ class SQLAlchemyDataStore(BaseExternalDataStore):
                             )
                         )
 
+                    # Release any schedules whose leases have expired
+                    columns = [
+                        self._t_schedules.c.id,
+                        self._t_schedules.c.task_id,
+                        self._t_schedules.c.next_fire_time,
+                    ]
+                    if not self._supports_tzaware_timestamps:
+                        columns.append(self._t_schedules.c.next_fire_time_utcoffset)
+
+                    query = select(*columns).where(
+                        self._t_schedules.c.acquired_by.isnot(None),
+                        self._t_schedules.c.acquired_until < now,
+                    )
+                    expired_schedule_ids: list[str] = []
+                    for row in await self._execute(conn, query):
+                        schedule_dict = self._convert_incoming_fire_times(row._asdict())
+                        expired_schedule_ids.append(schedule_dict["id"])
+                        events.append(
+                            ScheduleUpdated(
+                                schedule_id=schedule_dict["id"],
+                                task_id=schedule_dict["task_id"],
+                                next_fire_time=schedule_dict["next_fire_time"],
+                            )
+                        )
+
+                    if expired_schedule_ids:
+                        update = (
+                            self._t_schedules.update()
+                            .where(self._t_schedules.c.id.in_(expired_schedule_ids))
+                            .values(acquired_by=None, acquired_until=None)
+                        )
+                        await self._execute(conn, update)
+
                     # Clean up finished schedules that have no running jobs
                     query = (
                         select(self._t_schedules.c.id, self._t_schedules.c.task_id)

--- a/tests/test_datastores.py
+++ b/tests/test_datastores.py
@@ -697,6 +697,46 @@ async def test_next_schedule_run_time(datastore: DataStore, schedules: list[Sche
     platform.python_implementation() != "CPython",
     reason="time-machine is not available",
 )
+async def test_cleanup_expired_schedule_leases(
+    datastore: DataStore, schedules: list[Schedule], time_machine: TimeMachineFixture
+) -> None:
+    """
+    Test that clean-up releases schedules whose leases have expired, and notifies
+    schedulers about it.
+
+    """
+    time_machine.move_to(datetime(2020, 9, 14, tzinfo=timezone.utc))
+    await datastore.add_schedule(schedules[0], ConflictPolicy.exception)
+
+    # Acquire the schedule with a scheduler that then dies without releasing it
+    acquired = await datastore.acquire_schedules("scheduler1", timedelta(seconds=30), 1)
+    assert len(acquired) == 1
+
+    # The lease has not expired yet, so clean-up must leave the schedule alone
+    time_machine.shift(20)
+    await datastore.cleanup()
+    assert not await datastore.acquire_schedules("scheduler2", timedelta(seconds=30), 1)
+
+    # The lease has expired now, so clean-up releases the schedule
+    time_machine.shift(20)
+    async with capture_events(datastore, 1, {ScheduleUpdated}) as events:
+        await datastore.cleanup()
+
+    assert len(events) == 1
+    event = events[0]
+    assert isinstance(event, ScheduleUpdated)
+    assert event.schedule_id == schedules[0].id
+    assert event.task_id == schedules[0].task_id
+    assert event.next_fire_time == schedules[0].next_fire_time
+
+    acquired = await datastore.acquire_schedules("scheduler2", timedelta(seconds=30), 1)
+    assert [schedule.id for schedule in acquired] == [schedules[0].id]
+
+
+@pytest.mark.skipif(
+    platform.python_implementation() != "CPython",
+    reason="time-machine is not available",
+)
 async def test_extend_acquired_schedule_leases(
     datastore: DataStore, time_machine: TimeMachineFixture, schedules: list[Schedule]
 ) -> None:


### PR DESCRIPTION
Refs #1053.

Reworked to do it in housekeeping, as you suggested. `cleanup()` in all three data stores now
clears `acquired_by`/`acquired_until` on schedules whose leases have expired and publishes a
`ScheduleUpdated` for each one. A held schedule's `next_fire_time` is always in the past, so
`_process_schedules` wakes on the event and re-acquires it. The step is documented in the
`DataStore.cleanup()` contract in `abc.py`, next to the job lease one.

`get_next_schedule_run_time()` is back to exactly what master has.

Worth naming: recovery is now bounded by `cleanup_interval`, 15 minutes by default, rather than by
the lease duration. That is still a fix for a schedule that was otherwise stuck forever, and
`cleanup_interval` is the knob, but say the word if you want something tighter.

### Verification

Rebased onto current master first, so the cbor2 failures from the old run are gone.

```
pytest tests/test_datastores.py -k "memory or aiosqlite or mongodb"
73 passed, 1 skipped
```

`test_next_schedule_run_time_acquired` is replaced by `test_cleanup_expired_schedule_leases`, which
acquires a schedule, checks clean-up leaves a live lease alone, then checks it releases the schedule
and emits `ScheduleUpdated` once the lease expires. With `src/apscheduler/datastores/` reverted to
master it fails on all three of memory, aiosqlite and mongodb.

PostgreSQL and MySQL I still can't run locally. `ruff check` and `ruff format --check` are unchanged
from master.
