### PR TITLE
Raise ValueError for out-of-range numeric day_of_week values

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -26,6 +26,9 @@ APScheduler, see the :doc:`migration section <migration>`.
 - Fixed the synchronous ``Scheduler`` not enabling automatic clean-up by default,
   unlike ``AsyncScheduler``
   (`#1135 <https://github.com/agronholm/apscheduler/pull/1135>`_; PR by @dylanpulver)
+- Fixed ``CronTrigger`` raising an unhelpful ``IndexError`` instead of a descriptive
+  ``ValueError`` when given a numeric ``day_of_week`` value outside the 0–7 range
+  (`#1130 <https://github.com/agronholm/apscheduler/pull/1130>`_; PR by @nikolauspschuetz)
 
 **4.0.0a6**
 

--- a/src/apscheduler/triggers/cron/fields.py
+++ b/src/apscheduler/triggers/cron/fields.py
@@ -138,6 +138,10 @@ class DayOfWeekField(BaseField, real=False, extra_compilers=(WeekdayRangeExpress
         match = RangeExpression.value_re.match(expr)
         if match:
             groups = match.groups()
+            for group in groups[:2]:
+                if group is not None and not 0 <= int(group) <= 7:
+                    raise ValueError(f"Invalid weekday number {group!r}")
+
             first = int(groups[0]) - 1
             first = 6 if first < 0 else first
             if groups[1]:

--- a/tests/triggers/test_cron.py
+++ b/tests/triggers/test_cron.py
@@ -35,6 +35,12 @@ def test_invalid_weekday_name(expr):
     exc.match("Invalid weekday name 'web'")
 
 
+@pytest.mark.parametrize("expr", ["8", "0-8"], ids=["start", "end"])
+def test_invalid_weekday_number(expr):
+    exc = pytest.raises(ValueError, CronTrigger, day_of_week=expr)
+    exc.match("Invalid weekday number '8'")
+
+
 def test_invalid_weekday_position_name():
     exc = pytest.raises(ValueError, CronTrigger, day="1st web")
     exc.match("Invalid weekday name 'web'")


### PR DESCRIPTION
## Changes

No existing issue — linking to this PR in the changelog.

`CronTrigger` accepts numeric `day_of_week` values in the documented `0-7` range
(where both `0` and `7` mean Sunday). A value outside that range currently raises a
bare `IndexError: list index out of range` instead of a helpful error, because the
numeric value is mapped straight into `WEEKDAYS` before any range validation runs:

- `CronTrigger(day_of_week="8")` → `IndexError`
- `CronTrigger(day_of_week="0-8")` → `IndexError` (the range endpoint)
- `CronTrigger(day_of_week="7")` → OK (Sunday)

This validates the numeric bounds before the mapping and raises a descriptive
`ValueError`, mirroring the existing `Invalid weekday name '...'` messages in the same
module (e.g. `ValueError: Invalid weekday number '8'`).

## Checklist

- [x] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`) — n/a, error-message behavior only
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

### Notes

- The regression test `test_invalid_weekday_number` (parametrized `"8"`, `"0-8"`) fails on
  `master` with `IndexError` and passes with this patch.
- This only touches the numeric weekday-range branch (`first`/`last`). It does **not** touch
  the step branch (`groups[2]`, e.g. `"1-5/2"`) addressed by #1117 — no functional overlap,
  though the two changes are textually adjacent in the same method.

<sub>drafted with claude code — just for the record</sub>
