### PR TITLE
Keep the wakeup timer rearmed if _process_jobs raises exception.

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -4,6 +4,13 @@ Version history
 To find out how to migrate your application from a previous version of
 APScheduler, see the :doc:`migration section <migration>`.
 
+**UNRELEASED**
+
+- Fixed ``AsyncIOScheduler`` permanently stopping the processing of jobs if
+  ``_process_jobs()`` raised an exception, as the wakeup timer was then never rearmed
+  (`#PRNUM <https://github.com/agronholm/apscheduler/pull/PRNUM>`_; PR by
+  @sundasnoreen-sr)
+
 **3.11.3**
 
 - Fixed sub-minute interval jobs stalling for the duration of a DST spring-forward gap

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -8,8 +8,7 @@ APScheduler, see the :doc:`migration section <migration>`.
 
 - Fixed ``AsyncIOScheduler`` permanently stopping the processing of jobs if
   ``_process_jobs()`` raised an exception, as the wakeup timer was then never rearmed
-  (`#PRNUM <https://github.com/agronholm/apscheduler/pull/PRNUM>`_; PR by
-  @sundasnoreen-sr)
+  (`#1132 <https://github.com/agronholm/apscheduler/pull/1132>`_; PR by @sundasnoreen-sr)
 
 **3.11.3**
 

--- a/src/apscheduler/schedulers/asyncio.py
+++ b/src/apscheduler/schedulers/asyncio.py
@@ -69,7 +69,7 @@ class AsyncIOScheduler(BaseScheduler):
         try:
             wait_seconds = self._process_jobs()
         except Exception:
-            self._logger.exception('Error processing jobs')
+            self._logger.exception("Error processing jobs")
             wait_seconds = self.jobstore_retry_interval
         self._start_timer(wait_seconds)
 

--- a/src/apscheduler/schedulers/asyncio.py
+++ b/src/apscheduler/schedulers/asyncio.py
@@ -66,7 +66,11 @@ class AsyncIOScheduler(BaseScheduler):
     @run_in_event_loop
     def wakeup(self):
         self._stop_timer()
-        wait_seconds = self._process_jobs()
+        try:
+            wait_seconds = self._process_jobs()
+        except Exception:
+            self._logger.exception('Error processing jobs')
+            wait_seconds = self.jobstore_retry_interval
         self._start_timer(wait_seconds)
 
     def _create_default_executor(self):

--- a/src/apscheduler/schedulers/asyncio.py
+++ b/src/apscheduler/schedulers/asyncio.py
@@ -71,6 +71,7 @@ class AsyncIOScheduler(BaseScheduler):
         except Exception:
             self._logger.exception("Error processing jobs")
             wait_seconds = self.jobstore_retry_interval
+
         self._start_timer(wait_seconds)
 
     def _create_default_executor(self):

--- a/tests/test_schedulers.py
+++ b/tests/test_schedulers.py
@@ -1281,17 +1281,17 @@ class TestAsyncIOScheduler(SchedulerImplementationTestBase):
         scheduler does not stop processing jobs entirely.
 
         """
-        caplog.set_level(logging.ERROR, logger="apscheduler.schedulers")
+        caplog.set_level(logging.ERROR, logger="apscheduler.scheduler")
+        scheduler.jobstore_retry_interval = 3
         scheduler._eventloop = MagicMock()
         scheduler._process_jobs = MagicMock(side_effect=RuntimeError("Boom"))
 
         # Bypass the run_in_event_loop decorator to run wakeup() synchronously
         AsyncIOScheduler.wakeup.__wrapped__(scheduler)
 
-        scheduler._eventloop.call_later.assert_called_once_with(
-            scheduler.jobstore_retry_interval, scheduler.wakeup
-        )
+        scheduler._eventloop.call_later.assert_called_once_with(3, scheduler.wakeup)
         assert "Error processing jobs" in caplog.text
+        assert "RuntimeError: Boom" in caplog.text
 
 
 class TestGeventScheduler(SchedulerImplementationTestBase):

--- a/tests/test_schedulers.py
+++ b/tests/test_schedulers.py
@@ -1282,14 +1282,15 @@ class TestAsyncIOScheduler(SchedulerImplementationTestBase):
 
         """
         caplog.set_level(logging.ERROR, logger="apscheduler.scheduler")
-        scheduler.jobstore_retry_interval = 3
         scheduler._eventloop = MagicMock()
         scheduler._process_jobs = MagicMock(side_effect=RuntimeError("Boom"))
 
         # Bypass the run_in_event_loop decorator to run wakeup() synchronously
         AsyncIOScheduler.wakeup.__wrapped__(scheduler)
 
-        scheduler._eventloop.call_later.assert_called_once_with(3, scheduler.wakeup)
+        scheduler._eventloop.call_later.assert_called_once_with(
+            scheduler.jobstore_retry_interval, scheduler.wakeup
+        )
         assert "Error processing jobs" in caplog.text
         assert "RuntimeError: Boom" in caplog.text
 

--- a/tests/test_schedulers.py
+++ b/tests/test_schedulers.py
@@ -1275,6 +1275,24 @@ class TestAsyncIOScheduler(SchedulerImplementationTestBase):
         thread.join()
         event_loop.close()
 
+    def test_wakeup_rearms_timer_on_error(self, scheduler, caplog):
+        """
+        Test that the wakeup timer is rearmed even if ``_process_jobs()`` raises, so the
+        scheduler does not stop processing jobs entirely.
+
+        """
+        caplog.set_level(logging.ERROR, logger="apscheduler.schedulers")
+        scheduler._eventloop = MagicMock()
+        scheduler._process_jobs = MagicMock(side_effect=RuntimeError("Boom"))
+
+        # Bypass the run_in_event_loop decorator to run wakeup() synchronously
+        AsyncIOScheduler.wakeup.__wrapped__(scheduler)
+
+        scheduler._eventloop.call_later.assert_called_once_with(
+            scheduler.jobstore_retry_interval, scheduler.wakeup
+        )
+        assert "Error processing jobs" in caplog.text
+
 
 class TestGeventScheduler(SchedulerImplementationTestBase):
     @pytest.fixture


### PR DESCRIPTION
## Changes

Fixes (no existing issue)

### The problem

`AsyncIOScheduler.wakeup()` did three things in order:

1. stop the current timer
2. call `_process_jobs()`, which returns how long to sleep
3. start a new timer using that value

If step 2 raised an exception, step 3 never ran. The timer was already stopped
in step 1, so at that point **nothing was scheduled to wake the scheduler up
again**. `wakeup()` is invoked through `call_soon_threadsafe`, so the exception
just surfaced in the event loop and was lost. The scheduler stayed alive and
looked healthy, but it never ran another job.

The only way it could recover was by luck: any external call that happens to
invoke `wakeup()` again — `add_job()`, `modify_job()`, `resume()` — would start
a fresh timer. Nothing in the scheduler itself recovered on its own.

### What we observed in production

We hit this with `SQLAlchemyJobStore` on PostgreSQL:

1. `_process_jobs()` finished running the due jobs and called
   `jobstore.update_job()` to persist each job's next run time.
2. The PostgreSQL server closed the connection during the `COMMIT`.
3. The resulting exception escaped `_process_jobs()`, so the timer was never
   restarted.
4. The scheduler sat completely idle — no jobs ran, no errors were logged —
   until an unrelated `add_job()` call happened to re-arm the timer and bring
   it back to life.

A dropped database connection is a routine, transient event. It should not
permanently disable the scheduler, and it should not fail silently.

### The fix

Wrap the `_process_jobs()` call so that a failure is logged and the timer is
rearmed after `jobstore_retry_interval` instead of being left stopped. This
matches how `BlockingScheduler` already handles job store failures, and it
turns a permanent silent outage into a logged, self-healing retry.

## Checklist

- [x] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`) — n/a, bug fix only
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).