### PR TITLE
Declare the documented psycopg extra (#1133)

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -15,6 +15,9 @@ APScheduler, see the :doc:`migration section <migration>`.
   (`#1059 <https://github.com/agronholm/apscheduler/issues/1059>`_; PR by @jonasitzmann)
 - Fixed jobs that were being run when the scheduler was gracefully stopped being left in
   an acquired state (`#946 <https://github.com/agronholm/apscheduler/issues/946>`_)
+- Fixed the documented ``psycopg`` extra not being declared in the project metadata, so
+  ``pip install apscheduler[psycopg]`` silently installed nothing for the Psycopg event
+  broker (`#1133 <https://github.com/agronholm/apscheduler/issues/1133>`_)
 
 **4.0.0a6**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ asyncpg = ["asyncpg >= 0.20"]
 cbor = ["cbor2 >= 5.0"]
 mongodb = ["pymongo >= 4.13.0"]
 mqtt = ["paho-mqtt >= 2.0"]
+psycopg = ["psycopg >= 3.0"]
 redis = ["redis >= 5.0.1"]
 sqlalchemy = ["sqlalchemy[asyncio] >= 2.0.24"]
 


### PR DESCRIPTION
Fixes #1133

`docs/userguide.rst` documents a `psycopg` extra and tells users to install it with
`pip install apscheduler[psycopg,sqlalchemy]`, but `[project.optional-dependencies]`
never declared one. pip does not error on an unknown extra, so the user gets
`sqlalchemy`, no `psycopg`, and an `ImportError` later from
`apscheduler.eventbrokers.psycopg` with nothing pointing back at the install line.

## On the version floor

The issue reporter deliberately left this for you to name, so here is the data rather
than just a number.

I went with `>= 3.0` because that is the floor the code actually requires: the broker
uses `AsyncConnection.connect()`, `InterfaceError`, `conn.notifies()` (no arguments) and
`conn.execute()`, all of which are psycopg 3.0 APIs. Nothing in
`src/apscheduler/eventbrokers/psycopg.py` needs anything newer.

The tempting alternative — matching APScheduler's own supported Python range — does not
actually work as a rule. psycopg only added Python 3.13 in 3.2.3 and 3.14 in 3.3, so
"the floor that installs everywhere APScheduler runs" would be `>= 3.3`, which would
needlessly exclude working combinations on 3.10–3.12. Resolvers already pick a
psycopg version compatible with the running interpreter, so the low floor costs nothing.

Happy to raise it to `>= 3.1`, `>= 3.2` or `>= 3.3` if you would rather the extra track a
tested line — it is a one-word change, and I would rather you pick than have me guess.

## Two things I deliberately left alone

- The extra declares plain `psycopg`, not `psycopg[binary]`, matching how the other
  extras name their base package. `[dependency-groups] test` keeps its separate
  `psycopg[binary]` entry, since choosing the binary build is a deployment decision.
- I did not fold `psycopg` into the `APScheduler[cbor,mongodb,mqtt,redis,sqlalchemy]`
  line in the test group, because that would swap the test suite from `psycopg[binary]`
  to the source build.

Changelog entry added under **UNRELEASED**.
