### PR TITLE
Fixed the sync scheduler never running automatic clean-up

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -19,6 +19,9 @@ APScheduler, see the :doc:`migration section <migration>`.
 - Fixed the documented ``psycopg`` extra not being declared in the project metadata, so
   ``pip install apscheduler[psycopg]`` silently installed nothing for the Psycopg event
   broker (`#1133 <https://github.com/agronholm/apscheduler/issues/1133>`_)
+- Fixed the synchronous ``Scheduler`` never running automatic clean-up, as its
+  ``cleanup_interval`` argument defaulted to ``None`` (which disables clean-up) instead
+  of mirroring the 15 minute default of ``AsyncScheduler``
 
 **4.0.0a6**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -23,9 +23,8 @@ APScheduler, see the :doc:`migration section <migration>`.
   them; clean-up now releases schedules whose leases have expired and wakes up the
   other schedulers so they can acquire them
   (`#1053 <https://github.com/agronholm/apscheduler/issues/1053>`_)
-- Fixed the synchronous ``Scheduler`` never running automatic clean-up, as its
-  ``cleanup_interval`` argument defaulted to ``None`` (which disables clean-up) instead
-  of mirroring the 15 minute default of ``AsyncScheduler``
+- Fixed the synchronous ``Scheduler`` not enabling automatic clean-up by default,
+  unlike ``AsyncScheduler``
   (`#1135 <https://github.com/agronholm/apscheduler/pull/1135>`_; PR by @dylanpulver)
 
 **4.0.0a6**

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -22,6 +22,7 @@ APScheduler, see the :doc:`migration section <migration>`.
 - Fixed the synchronous ``Scheduler`` never running automatic clean-up, as its
   ``cleanup_interval`` argument defaulted to ``None`` (which disables clean-up) instead
   of mirroring the 15 minute default of ``AsyncScheduler``
+  (`#1135 <https://github.com/agronholm/apscheduler/pull/1135>`_; PR by @dylanpulver)
 
 **4.0.0a6**
 

--- a/src/apscheduler/_schedulers/sync.py
+++ b/src/apscheduler/_schedulers/sync.py
@@ -55,7 +55,7 @@ class Scheduler:
         identity: str = "",
         role: SchedulerRole = SchedulerRole.both,
         max_concurrent_jobs: int = 100,
-        cleanup_interval: float | timedelta | None = None,
+        cleanup_interval: float | timedelta | None = timedelta(minutes=15),
         lease_duration: timedelta = timedelta(seconds=30),
         job_executors: MutableMapping[str, JobExecutor] | None = None,
         task_defaults: TaskDefaults | None = None,

--- a/tests/test_schedulers.py
+++ b/tests/test_schedulers.py
@@ -1498,15 +1498,6 @@ class TestSyncScheduler:
             with pytest.raises(ScheduleLookupError):
                 scheduler.get_schedule("event_set")
 
-    def test_default_cleanup_interval(self) -> None:
-        """
-        Test that the sync scheduler defaults to the same clean-up interval as the
-        async scheduler instead of disabling automatic clean-up.
-
-        """
-        assert Scheduler().cleanup_interval == timedelta(minutes=15)
-        assert Scheduler().cleanup_interval == AsyncScheduler().cleanup_interval
-
     def test_implicit_cleanup(self, mocker: MockerFixture) -> None:
         """
         Test that the data store's cleanup() method is called when a scheduler

--- a/tests/test_schedulers.py
+++ b/tests/test_schedulers.py
@@ -16,6 +16,7 @@ from typing import Any, cast
 from unittest.mock import patch
 
 import anyio
+import attrs
 import pytest
 from anyio import (
     Lock,
@@ -1237,6 +1238,57 @@ class TestSyncScheduler:
                     assert args == sync_args[kind], (
                         f"Parameter mismatch for {attrname}(): {args} != {sync_args[kind]}"
                     )
+
+    def test_constructor_parity(self) -> None:
+        """
+        Ensure that the sync scheduler accepts the same constructor arguments as the
+        async scheduler, with the same default values.
+
+        The loop in :meth:`test_interface_parity` skips ``__init__`` because it only
+        looks at public attributes, so the constructor defaults – the one place where
+        the two schedulers can silently drift apart – are compared here instead.
+
+        """
+        # Constructor arguments whose declared defaults intentionally differ.
+        # Scheduler only forwards the options it was actually given, so it uses None as
+        # an "argument not passed" sentinel for every option whose real default is an
+        # object built by AsyncScheduler itself (an attrs factory, or the module level
+        # logger); the effective default still comes from AsyncScheduler.
+        # task_defaults is additionally sync-specific, as Scheduler fills in the
+        # "threadpool" job executor.
+        exceptions = {
+            "data_store",
+            "event_broker",
+            "job_executors",
+            "task_defaults",
+            "logger",
+        }
+        async_params = signature(AsyncScheduler.__init__).parameters
+        sync_params = signature(Scheduler.__init__).parameters
+        converters = {
+            field.name: field.converter for field in attrs.fields(AsyncScheduler)
+        }
+        for name, async_param in async_params.items():
+            if name == "self":
+                continue
+
+            if name not in sync_params:
+                pytest.fail(f"Scheduler() is missing the {name!r} argument")
+
+            if name in exceptions:
+                continue
+
+            # Compare the defaults the way AsyncScheduler stores them, by running both
+            # through the field's converter (if any), as lease_duration is declared as a
+            # plain number of seconds on the async side but as a timedelta on the sync
+            # side.
+            convert = converters[name] or (lambda value: value)
+            async_default = convert(async_param.default)
+            sync_default = convert(sync_params[name].default)
+            assert sync_default == async_default, (
+                f"Default value mismatch for the {name!r} argument of Scheduler(): "
+                f"{sync_default!r} != {async_default!r}"
+            )
 
     def test_repr(self) -> None:
         scheduler = Scheduler(identity="my identity")

--- a/tests/test_schedulers.py
+++ b/tests/test_schedulers.py
@@ -1446,6 +1446,27 @@ class TestSyncScheduler:
             with pytest.raises(ScheduleLookupError):
                 scheduler.get_schedule("event_set")
 
+    def test_default_cleanup_interval(self) -> None:
+        """
+        Test that the sync scheduler defaults to the same clean-up interval as the
+        async scheduler instead of disabling automatic clean-up.
+
+        """
+        assert Scheduler().cleanup_interval == timedelta(minutes=15)
+        assert Scheduler().cleanup_interval == AsyncScheduler().cleanup_interval
+
+    def test_implicit_cleanup(self, mocker: MockerFixture) -> None:
+        """
+        Test that the data store's cleanup() method is called when a scheduler
+        configured with the default options is started.
+
+        """
+        with Scheduler() as scheduler:
+            event = threading.Event()
+            mocker.patch.object(scheduler.data_store, "cleanup", side_effect=event.set)
+            scheduler.start_in_background()
+            assert event.wait(3)
+
     def test_run_until_stopped(self) -> None:
         queue: Queue[Event] = Queue()
         with Scheduler() as scheduler:


### PR DESCRIPTION
## Changes

`Scheduler` is documented as a synchronous wrapper for `AsyncScheduler`, pointing at that
class for the meaning of its configuration options. One default does not match:

```python
>>> from apscheduler import AsyncScheduler, Scheduler
>>> AsyncScheduler().cleanup_interval
datetime.timedelta(seconds=900)
>>> Scheduler().cleanup_interval
None
```

`Scheduler.__init__` declares `cleanup_interval: float | timedelta | None = None` and
forwards the value unconditionally, so `AsyncScheduler` receives an explicit `None`.
`None` is the documented "disable automatic clean-up" value, so `_cleanup_loop` never
starts for a sync scheduler built with default options and the data store keeps expired
job results and finished schedules forever. The user guide states that each scheduler
runs the data store's `cleanup()` method periodically.

Both defaults arrived in 56274e4, which added the option to the two classes in one
commit and gave the sync side `None`. The other scalar options in that signature do
mirror the async defaults (`max_concurrent_jobs=100`,
`lease_duration=timedelta(seconds=30)`), and `test_interface_parity` skips dunder names,
so `__init__` is the one part of the wrapper the parity test never compares.

The fix mirrors the async default the way the sibling options do. One added test asserts
directly on `Scheduler().cleanup_interval` and on parity with `AsyncScheduler()`. The
other checks that a default sync scheduler reaches the data store's `cleanup()`. Both
fail on master.

## Checklist

- [x] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

<!-- Docs box left unchecked on purpose: the "Clean-up of expired jobs, job results and
schedules" section of the user guide describes the behaviour this restores, so there was
nothing to change under docs/. -->
