### PR TITLE
Fix combining trigger comparisons across DST transitions

### DIFF
--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -437,11 +437,6 @@ If this trigger is created on 2022-06-07 at 09:00:00, its first run times would 
 
 Notably, 2022-08-07 is skipped because it falls on a Sunday.
 
-Both combining triggers compare run times as absolute instants. During a daylight saving
-time rollback, two occurrences of the same local clock time remain distinct. The
-``AndTrigger`` threshold measures elapsed time, including across daylight saving time
-transitions. Returned run times retain the time zones of their originating triggers.
-
 Removing schedules
 ------------------
 

--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -437,6 +437,11 @@ If this trigger is created on 2022-06-07 at 09:00:00, its first run times would 
 
 Notably, 2022-08-07 is skipped because it falls on a Sunday.
 
+Both combining triggers compare run times as absolute instants. During a daylight saving
+time rollback, two occurrences of the same local clock time remain distinct. The
+``AndTrigger`` threshold measures elapsed time, including across daylight saving time
+transitions. Returned run times retain the time zones of their originating triggers.
+
 Removing schedules
 ------------------
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -9,7 +9,7 @@ APScheduler, see the :doc:`migration section <migration>`.
 - Fixed combining triggers comparing local clock times instead of absolute instants,
   which could skip or duplicate runs in ``OrTrigger`` and incorrectly match or discard
   runs in ``AndTrigger`` around daylight saving time transitions
-  (PR by @Kuang-xianxin)
+  (`#1137 <https://github.com/agronholm/apscheduler/pull/1137>`_; PR by @Kuang-xianxin)
 - **BREAKING** Switched the MongoDB data store to use the asynchronous API in
   ``pymongo`` and bumped the minimum ``pymongo`` version to v4.13.0
 - Bumped up the CBOR serializer's ``cbor2`` dependency to v6.0+

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -6,6 +6,10 @@ APScheduler, see the :doc:`migration section <migration>`.
 
 **UNRELEASED**
 
+- Fixed combining triggers comparing local clock times instead of absolute instants,
+  which could skip or duplicate runs in ``OrTrigger`` and incorrectly match or discard
+  runs in ``AndTrigger`` around daylight saving time transitions
+  (PR by @Kuang-xianxin)
 - **BREAKING** Switched the MongoDB data store to use the asynchronous API in
   ``pymongo`` and bumped the minimum ``pymongo`` version to v4.13.0
 - Bumped up the CBOR serializer's ``cbor2`` dependency to v6.0+

--- a/src/apscheduler/_utils.py
+++ b/src/apscheduler/_utils.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime, tzinfo
+from datetime import datetime, timezone, tzinfo
 from typing import TYPE_CHECKING, Any, NoReturn, TypeVar
 from zoneinfo import ZoneInfo
 
@@ -50,7 +50,9 @@ def timezone_repr(timezone: tzinfo) -> str:
 
 
 def absolute_datetime_diff(dateval1: datetime, dateval2: datetime) -> float:
-    return dateval1.timestamp() - dateval2.timestamp()
+    return (
+        dateval1.astimezone(timezone.utc) - dateval2.astimezone(timezone.utc)
+    ).total_seconds()
 
 
 def qualified_name(cls: type) -> str:

--- a/src/apscheduler/triggers/combining.py
+++ b/src/apscheduler/triggers/combining.py
@@ -9,7 +9,7 @@ import attrs
 from .._converters import as_aware_datetime, as_timedelta, list_converter
 from .._exceptions import MaxIterationsReached
 from .._marshalling import marshal_object, unmarshal_object
-from .._utils import require_state_version
+from .._utils import absolute_datetime_diff, require_state_version
 from ..abc import Trigger
 
 
@@ -65,6 +65,7 @@ class AndTrigger(BaseCombiningTrigger):
             # Fill out the fire times on the first run
             self._next_fire_times = [t.next() for t in self.triggers]
 
+        threshold = self.threshold.total_seconds()
         for _ in range(self.max_iterations):
             # Find the earliest and latest fire times
             earliest_fire_time: datetime | None = None
@@ -74,32 +75,30 @@ class AndTrigger(BaseCombiningTrigger):
                 if fire_time is None:
                     return None
 
-                # Compare instants, not wall times: datetime comparisons ignore fold
-                # when both operands share the same tzinfo.
-                if earliest_fire_time is None or earliest_fire_time.astimezone(
-                    timezone.utc
-                ) > fire_time.astimezone(timezone.utc):
+                if (
+                    earliest_fire_time is None
+                    or absolute_datetime_diff(earliest_fire_time, fire_time) > 0
+                ):
                     earliest_fire_time = fire_time
 
-                if latest_fire_time is None or latest_fire_time.astimezone(
-                    timezone.utc
-                ) < fire_time.astimezone(timezone.utc):
+                if (
+                    latest_fire_time is None
+                    or absolute_datetime_diff(latest_fire_time, fire_time) < 0
+                ):
                     latest_fire_time = fire_time
 
             # Replace all the fire times that were within the threshold
             for i, _trigger in enumerate(self.triggers):
                 if (
-                    self._next_fire_times[i].astimezone(timezone.utc)
-                    - earliest_fire_time.astimezone(timezone.utc)
-                    <= self.threshold
+                    absolute_datetime_diff(self._next_fire_times[i], earliest_fire_time)
+                    <= threshold
                 ):
                     self._next_fire_times[i] = self.triggers[i].next()
 
             # If all the fire times were within the threshold, return the earliest one
             if (
-                latest_fire_time.astimezone(timezone.utc)
-                - earliest_fire_time.astimezone(timezone.utc)
-                <= self.threshold
+                absolute_datetime_diff(latest_fire_time, earliest_fire_time)
+                <= threshold
             ):
                 return earliest_fire_time
         else:
@@ -152,9 +151,10 @@ class OrTrigger(BaseCombiningTrigger):
             # Generate new fire times for the trigger(s) that generated the earliest
             # fire time
             for i, fire_time in enumerate(self._next_fire_times):
-                if fire_time is not None and fire_time.astimezone(
-                    timezone.utc
-                ) == earliest_time.astimezone(timezone.utc):
+                if (
+                    fire_time is not None
+                    and absolute_datetime_diff(fire_time, earliest_time) == 0
+                ):
                     self._next_fire_times[i] = self.triggers[i].next()
 
         return earliest_time

--- a/src/apscheduler/triggers/combining.py
+++ b/src/apscheduler/triggers/combining.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import attrs
@@ -74,19 +74,33 @@ class AndTrigger(BaseCombiningTrigger):
                 if fire_time is None:
                     return None
 
-                if earliest_fire_time is None or earliest_fire_time > fire_time:
+                # Compare instants, not wall times: datetime comparisons ignore fold
+                # when both operands share the same tzinfo.
+                if earliest_fire_time is None or earliest_fire_time.astimezone(
+                    timezone.utc
+                ) > fire_time.astimezone(timezone.utc):
                     earliest_fire_time = fire_time
 
-                if latest_fire_time is None or latest_fire_time < fire_time:
+                if latest_fire_time is None or latest_fire_time.astimezone(
+                    timezone.utc
+                ) < fire_time.astimezone(timezone.utc):
                     latest_fire_time = fire_time
 
             # Replace all the fire times that were within the threshold
             for i, _trigger in enumerate(self.triggers):
-                if self._next_fire_times[i] - earliest_fire_time <= self.threshold:
+                if (
+                    self._next_fire_times[i].astimezone(timezone.utc)
+                    - earliest_fire_time.astimezone(timezone.utc)
+                    <= self.threshold
+                ):
                     self._next_fire_times[i] = self.triggers[i].next()
 
             # If all the fire times were within the threshold, return the earliest one
-            if latest_fire_time - earliest_fire_time <= self.threshold:
+            if (
+                latest_fire_time.astimezone(timezone.utc)
+                - earliest_fire_time.astimezone(timezone.utc)
+                <= self.threshold
+            ):
                 return earliest_fire_time
         else:
             raise MaxIterationsReached
@@ -131,13 +145,16 @@ class OrTrigger(BaseCombiningTrigger):
         # Find out the earliest of the fire times
         earliest_time: datetime | None = min(
             (fire_time for fire_time in self._next_fire_times if fire_time is not None),
+            key=lambda fire_time: fire_time.astimezone(timezone.utc),
             default=None,
         )
         if earliest_time is not None:
             # Generate new fire times for the trigger(s) that generated the earliest
             # fire time
             for i, fire_time in enumerate(self._next_fire_times):
-                if fire_time == earliest_time:
+                if fire_time is not None and fire_time.astimezone(
+                    timezone.utc
+                ) == earliest_time.astimezone(timezone.utc):
                     self._next_fire_times[i] = self.triggers[i].next()
 
         return earliest_time

--- a/tests/triggers/test_combining.py
+++ b/tests/triggers/test_combining.py
@@ -13,6 +13,17 @@ from apscheduler.triggers.interval import IntervalTrigger
 
 
 class TestAndTrigger:
+    def test_microsecond_threshold(self, timezone):
+        date1 = datetime(2024, 10, 27, 2, 30, microsecond=2, tzinfo=timezone)
+        date2 = date1 + timedelta(microseconds=1)
+        trigger = AndTrigger(
+            [DateTrigger(date1), DateTrigger(date2)],
+            threshold=timedelta(microseconds=1),
+        )
+
+        assert trigger.next() == date1
+        assert trigger.next() is None
+
     @pytest.mark.parametrize(
         "date1,date2,threshold,expected_match",
         [

--- a/tests/triggers/test_combining.py
+++ b/tests/triggers/test_combining.py
@@ -13,6 +13,50 @@ from apscheduler.triggers.interval import IntervalTrigger
 
 
 class TestAndTrigger:
+    @pytest.mark.parametrize(
+        "date1,date2,threshold,expected_match",
+        [
+            (
+                datetime(2024, 10, 27, 2, 30),
+                datetime(2024, 10, 27, 2, 30, fold=1),
+                1,
+                False,
+            ),
+            (
+                datetime(2024, 10, 27, 2, 59, 59, 500000),
+                datetime(2024, 10, 27, 2, fold=1),
+                1,
+                True,
+            ),
+            (
+                datetime(2024, 3, 31, 1, 59, 59, 500000),
+                datetime(2024, 3, 31, 3),
+                1,
+                True,
+            ),
+        ],
+        ids=["distinct-folds", "fall-back-threshold", "spring-forward-threshold"],
+    )
+    @pytest.mark.parametrize("reverse", [False, True])
+    def test_dst_threshold(
+        self, timezone, date1, date2, threshold, expected_match, reverse
+    ):
+        date1 = date1.replace(tzinfo=timezone)
+        date2 = date2.replace(tzinfo=timezone)
+        dates = [date1, date2]
+        if reverse:
+            dates.reverse()
+
+        trigger = AndTrigger([DateTrigger(date) for date in dates], threshold=threshold)
+        result = trigger.next()
+        if expected_match:
+            assert result is not None
+            assert result.timestamp() == date1.timestamp()
+        else:
+            assert result is None
+
+        assert trigger.next() is None
+
     @pytest.mark.parametrize("threshold", [1, 0])
     def test_two_datetriggers(self, timezone, serializer, threshold):
         date1 = datetime(2020, 5, 16, 14, 17, 30, 254212, tzinfo=timezone)
@@ -163,6 +207,44 @@ class TestAndTrigger:
 
 
 class TestOrTrigger:
+    @pytest.mark.parametrize("reverse", [False, True])
+    @pytest.mark.parametrize("same_wall_time", [False, True])
+    def test_dst_fall_back(self, timezone, serializer, reverse, same_wall_time):
+        date1 = datetime(2024, 10, 27, 2, 30, tzinfo=timezone)
+        date2 = datetime(
+            2024, 10, 27, 2, 30 if same_wall_time else 0, tzinfo=timezone, fold=1
+        )
+        dates = [date1, date2]
+        if reverse:
+            dates.reverse()
+
+        trigger = OrTrigger([DateTrigger(date) for date in dates])
+        result = trigger.next()
+        assert result is not None
+        assert result.timestamp() == date1.timestamp()
+
+        if serializer:
+            trigger = serializer.deserialize(serializer.serialize(trigger))
+
+        result = trigger.next()
+        assert result is not None
+        assert result.timestamp() == date2.timestamp()
+        assert trigger.next() is None
+
+    @pytest.mark.parametrize("fold", [0, 1])
+    @pytest.mark.parametrize("reverse", [False, True])
+    def test_dst_same_instant(self, timezone, utc_timezone, fold, reverse):
+        date = datetime(2024, 10, 27, 2, 30, tzinfo=timezone, fold=fold)
+        dates = [date, date.astimezone(utc_timezone)]
+        if reverse:
+            dates.reverse()
+
+        trigger = OrTrigger([DateTrigger(value) for value in dates])
+        result = trigger.next()
+        assert result is not None
+        assert result.timestamp() == date.timestamp()
+        assert trigger.next() is None
+
     def test_two_datetriggers(self, timezone, serializer):
         date1 = datetime(2020, 5, 16, 14, 17, 30, 254212, tzinfo=timezone)
         date2 = datetime(2020, 5, 18, 15, 1, 53, 940564, tzinfo=timezone)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

During the October clock rollback in Europe/Berlin, `02:30+02:00` and `02:30+01:00` are an hour apart. Python compares these datetimes as equal when they share the same `ZoneInfo`, so `OrTrigger` can lose a run, return rollback times out of order, or duplicate the same instant represented in another timezone. `AndTrigger` can accept times an hour apart within a one-second threshold and discard times only half a second apart across a DST transition.

Use `absolute_datetime_diff()` for comparisons, deduplication and thresholds. The helper subtracts UTC datetimes before converting the difference to seconds, preserving microsecond threshold boundaries that epoch-float subtraction can round incorrectly. The `OrTrigger` minimum uses a UTC datetime key. Original child datetimes and serialized state remain unchanged.

Validation on Windows, CPython 3.13.14:

- All 22 DST regression cases fail on the original `e1afa74`; they cover both child orders, both folds, spring-forward/fall-back thresholds and partially consumed trigger round-trips through pickle, CBOR and JSON.
- An additional public `AndTrigger` test fails with the helper's original epoch-float subtraction: an exact 1-microsecond difference becomes approximately 1.192 microseconds and exceeds a 1-microsecond threshold. It passes with UTC subtraction.
- `pytest -m 'not external_service' -q`: **395 passed, 2 skipped, 492 deselected**. External database/message-broker services were not run.
- All applicable automatic pre-commit hooks pass. The optional manual mypy hook reports 72 diagnostics on both the current change and untouched `e1afa74`: 68 are identical, and four pre-existing optional-datetime paths now produce argument errors instead of subtraction errors. No complete type-check pass is claimed.
- The initial strict Sphinx build reported 14 API type-reference warnings, also reproduced on untouched `e1afa74`. The added user-guide paragraph has been removed per review; the changelog records the fix.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue #999, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/apscheduler/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
