### PR TITLE
Fix calendar interval dates after midnight DST gaps

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -29,6 +29,8 @@ APScheduler, see the :doc:`migration section <migration>`.
 - Fixed type annotation of ``AndTrigger.max_iterations`` to only allow ``int`` and never
   ``None``
   (`#1131 <https://github.com/agronholm/apscheduler/issues/1131>`_; PR by @afonsojanu)
+- Fixed ``CalendarIntervalTrigger`` skipping valid dates or shifting subsequent run dates
+  when a nonexistent local time normalizes past midnight during a forward DST shift
 
 **4.0.0a6**
 

--- a/src/apscheduler/triggers/calendarinterval.py
+++ b/src/apscheduler/triggers/calendarinterval.py
@@ -119,7 +119,7 @@ class CalendarIntervalTrigger(Trigger):
 
             # Check if the time is off due to normalization and a forward DST shift
             if next_time.timetz() != self._time:
-                previous_date = next_time.date()
+                previous_date = next_date
             else:
                 self._last_fire_date = next_date
                 return next_time

--- a/tests/triggers/test_calendarinterval.py
+++ b/tests/triggers/test_calendarinterval.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-from datetime import date, datetime
+from datetime import date, datetime, time
+from zoneinfo import ZoneInfo
 
 import pytest
 
+from apscheduler.abc import Serializer
 from apscheduler.triggers.calendarinterval import CalendarIntervalTrigger
 
 
@@ -50,6 +52,96 @@ def test_missing_time(timezone, serializer):
         trigger = serializer.deserialize(serializer.serialize(trigger))
 
     assert trigger.next() == datetime(2016, 3, 28, 2, 30, tzinfo=timezone)
+
+
+@pytest.mark.parametrize(
+    "years, months, weeks, days, start_date, expected_dates",
+    [
+        pytest.param(
+            0,
+            0,
+            0,
+            1,
+            date(2024, 3, 29),
+            (date(2024, 3, 29), date(2024, 3, 31), date(2024, 4, 1)),
+            id="daily",
+        ),
+        pytest.param(
+            0,
+            0,
+            0,
+            1,
+            date(2024, 3, 30),
+            (date(2024, 3, 31),),
+            id="start-in-gap-end-on-next-day",
+        ),
+        pytest.param(
+            0,
+            0,
+            0,
+            2,
+            date(2024, 3, 28),
+            (date(2024, 3, 28), date(2024, 4, 1), date(2024, 4, 3)),
+            id="every-other-day",
+        ),
+        pytest.param(
+            0,
+            0,
+            1,
+            0,
+            date(2024, 3, 23),
+            (date(2024, 3, 23), date(2024, 4, 6), date(2024, 4, 13)),
+            id="weekly",
+        ),
+        pytest.param(
+            0,
+            1,
+            0,
+            0,
+            date(2024, 1, 30),
+            (date(2024, 1, 30), date(2024, 4, 30), date(2024, 5, 30)),
+            id="monthly",
+        ),
+        pytest.param(
+            1,
+            0,
+            0,
+            0,
+            date(2023, 3, 30),
+            (date(2023, 3, 30), date(2025, 3, 30), date(2026, 3, 30)),
+            id="yearly",
+        ),
+    ],
+)
+def test_missing_time_crossing_midnight(
+    years: int,
+    months: int,
+    weeks: int,
+    days: int,
+    start_date: date,
+    expected_dates: tuple[date, ...],
+    serializer: Serializer | None,
+) -> None:
+    # Nuuk's missing 2024-03-30 23:30 normalizes to 2024-03-31 00:30.
+    timezone = ZoneInfo("America/Nuuk")
+    trigger = CalendarIntervalTrigger(
+        years=years,
+        months=months,
+        weeks=weeks,
+        days=days,
+        hour=23,
+        minute=30,
+        start_date=start_date,
+        end_date=expected_dates[-1],
+        timezone=timezone,
+    )
+    for expected_date in expected_dates:
+        if serializer:
+            trigger = serializer.deserialize(serializer.serialize(trigger))
+
+        assert trigger.next() == datetime.combine(expected_date, time(23, 30), timezone)
+
+    assert trigger.next() is None
 
 
 def test_repeated_time(timezone, serializer):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

In `America/Nuuk`, a daily 23:30 `CalendarIntervalTrigger` starting on 2024-03-29 skips the valid March 31 run after the March 30 DST gap:

- Before: March 29 → April 1 → April 2.
- After: March 29 → March 31 → April 1.

The nonexistent March 30 23:30 normalizes to March 31 00:30. After rejecting this time, the original implementation uses the normalized date as the next iteration's reference, then adds the interval again. This can also shift subsequent weekly, monthly and yearly dates, or exhaust a trigger before its valid inclusive end date.

Keep the attempted `next_date` as the reference when discarding an invalid local time. The existing interval calculation, wall-clock time, end-date handling and serialized state format remain unchanged. No dependencies are added.

Validation on Windows, CPython 3.12.10, tzdata 2026.3, based on `e1afa7471d1fc2c3ea7a2b730ef68db20743774a`:

- All 18 new regression cases fail on the original implementation. They cover daily, every-other-day, weekly, monthly and yearly intervals, a start date inside the gap, the inclusive end date, and repeated pickle/CBOR/JSON round-trips.
- `pytest tests/triggers tests/test_serializers.py -q`: 197 passed, including the new cases.
- A separate public-API reproduction produces the expected March 29 → March 31 → April 1 sequence after the fix.
- All applicable automatic pre-commit hooks pass for the three changed files, and `git diff --check` passes.

The existing `CalendarIntervalTrigger` documentation already specifies discarding nonexistent local times and advancing to the next calendar date, so no user-guide changes are needed. The full cross-platform Python matrix, external-service suite and optional manual mypy hook were not run locally. The changelog entry will be linked to this PR once its number is assigned.

AI assistance: Codex assisted with investigation, implementation and regression tests. The validation above was executed locally against the modified source.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue #999, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/apscheduler/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
